### PR TITLE
EOS S3 HAL release

### DIFF
--- a/.github/license_config.yml
+++ b/.github/license_config.yml
@@ -1,0 +1,16 @@
+license:
+  main: apache-2.0
+  category: Permissive
+copyright:
+  check: false
+exclude:
+  extensions:
+    - yml
+    - yaml
+    - html
+    - rst
+    - conf
+    - cfg
+  langs:
+    - HTML
+

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,25 @@
+name: Scancode
+
+on: [pull_request]
+
+jobs:
+  scancode_job:
+    runs-on: ubuntu-latest
+    name: Scan code for licenses
+    steps:
+    - uses: actions/checkout@v1
+    - name: Scan the code
+      id: scancode
+      uses: zephyrproject-rtos/action_scancode@v2
+      with:
+        directory-to-scan: 'scan/'
+    - name: Artifact Upload
+      uses: actions/upload-artifact@v1
+      with:
+        name: scancode
+        path: ./artifacts
+
+    - name: Verify
+      run: |
+        test ! -s ./artifacts/report.txt || (cat ./artifacts/report.txt && exit 1 )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+# QuickLogic HAL
+#
+# Copyright (c) 2020 Antmicro Ltd <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_EOS_S3_HAL)
+  zephyr_include_directories(
+    HAL/inc
+  )
+  add_subdirectory(HAL/src)
+endif()

--- a/HAL/inc/eoss3_api.h
+++ b/HAL/inc/eoss3_api.h
@@ -1,0 +1,37 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_api.h
+ *    Purpose   : This header file contains the descriptions
+ *             and definitions for the application level APIs 
+ *             for the various BSP subsystem firmware
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef _eoss3_api_h
+#define _eoss3_api_h
+#include <stdint.h>
+#include <stddef.h>
+
+
+/*
+ * FLASH API
+ */
+int flash_pwrmode(int);
+// int flash_init(...);
+
+#endif /* !_eoss3_api_h */

--- a/HAL/inc/eoss3_dev.h
+++ b/HAL/inc/eoss3_dev.h
@@ -1,0 +1,2501 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_dev.h
+ *    Purpose   : This file contains device mapping for
+ *             interrupt vector, peripherals register mapping 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_DEV_H
+#define __EOSS3_DEV_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+     
+#include <stdint.h>
+
+/// @cond EOSS3_DEV_MACROS
+/**
+  * @brief Configuration of the Cortex-M4 Processor and Core Peripherals
+  */
+#define __CM4_REV                 0x0001  /*!< Core revision r0p1                            */
+#define __MPU_PRESENT             1       /*!< Tamar provides an MPU                     */
+#define __NVIC_PRIO_BITS          3       /*!< Tamar uses 3 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    1       /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1       /*!< FPU present                                   */
+
+/*
+ * Interrupt Number Definition
+ */
+
+typedef enum
+{
+/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M4 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M4 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M4 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M4 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M4 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M4 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                                */
+/******  Specific Interrupt Numbers **********************************************************************/
+  SwInt2_IRQn           	  = 0,
+  SwInt1_IRQn  		          = 1,
+  Reserved1_IRQn	          = 2,
+  Ffe0Msg_IRQn                = 3,
+  FbMsg_IRQn          	      = 4,
+  Gpio_IRQn                   = 5,
+  SramSleep_IRQn              = 6,
+  Uart_IRQn                   = 7,
+  Timer_IRQn                  = 8,
+  CpuWdtInt_IRQn              = 9,
+  CpuWdtRst_IRQn              = 10,
+  BusTimeout_IRQn             = 11,
+  Fpu_IRQn                    = 12,
+  Pkfb_IRQn                   = 13,
+  Reserved_I2s_IRQn           = 14,
+  Reserved_Audio_IRQn         = 15,
+  SpiMs_IRQn                  = 16,
+  CfgDma_IRQn                 = 17,
+  PmuTimer_IRQn               = 18,
+  AdcDone_IRQn                = 19,
+  RtcAlarm_IRQn               = 20,
+  ResetInt_IRQn               = 21,
+  Ffe0_IRQn                   = 22,
+  FfeWdt_IRQn                 = 23,
+  ApBoot_IRQn                 = 24,
+  Ldo30_pg_IRQn               = 25,
+  Ldo50_pg_IRQn               = 26,
+  Sram_to_IRQn                = 27,
+  Lpsd_IRQn					  = 28,
+  Dmic_IRQn					  = 29,
+  Reserved2_IRQn  			  = 30,
+  Sdma_Done1_IRQn  			  = 31,
+  Sdma_Done2_IRQn  			  = 32,
+  Sdma_Done3_IRQn  			  = 33,
+  Sdma_Done4_IRQn  			  = 34,
+  Sdma_Done5_IRQn  			  = 35,
+  Sdma_Done6_IRQn  			  = 36,
+  Sdma_Done7_IRQn  			  = 37,
+  Sdma_Done8_IRQn  			  = 38,
+  Sdma_Done9_IRQn  			  = 39,
+  Sdma_Done10_IRQn  		  = 40,
+  Sdma_Done11_IRQn  		  = 41,
+  Ap_Pdm_Clock_On_IRQn 		  = 42,
+  Ap_Pdm_Clock_Off_IRQn       = 43,
+  Dmac0_Block_Done_IRQn 	  = 44,
+  Dmac0_Buffer_Done_IRQn      = 45,
+  Dmac1_Block_Done_IRQn       = 46,
+  Dmac1_Buffer_Done_IRQn      = 47,
+  Sdma_Done0_IRQn  		  	  = 48,
+  Sdma_Err_IRQn  		      = 49,
+  I2SSlv_M4_IRQn  		      = 50,
+  Lpsd_Voice_Off_IRQn		  = 51,
+  Dmic_Voice_Off_IRQn		  = 52
+
+} IRQn_Type;
+#include <core_cm4.h>             /* Cortex-M4 processor and core peripherals */
+
+/*
+ * Peripheral_registers_structures
+ */
+
+/*
+ * Uart
+ */
+typedef struct
+{
+	__IO uint32_t UART_DR;		/* Data Address: 0x00 */
+	__IO uint32_t UART_RSR;         /* Receive Status Register: 0x04 */
+	__IO uint32_t reserved1[4];		/* Reserved: 0x08 - 0x14 */
+	__IO uint32_t UART_TFR;		/* Flag Register 0x18 */
+	__IO uint32_t reserved2[1];         /* Reserved 0x1C */
+	__IO uint32_t UART_ILPR;        /* IrDA Low Power Counter Register 0x20 */
+	__IO uint32_t UART_IBRD;        /* Integer Baud Rate Register 0x24 */
+	__IO uint32_t UART_FBRD;        /* Fractional Baud Rate Register 0x28 */
+	__IO uint32_t UART_LCR_H;       /* Line Control Register 0x2C */
+	__IO uint32_t UART_CR;          /* Control Register 0x30 */
+	__IO uint32_t UART_IFLS;        /* Interrupt FIFO Level Select Register 0x34 */
+	__IO uint32_t UART_IMSC;        /* Interrupt Mask Set/Clear Register 0x38 */
+	__IO uint32_t UART_RIS;         /* Raw Interrupt Status Register 0x3C */
+	__IO uint32_t UART_MIS;         /* Masked Interrupt Status Register 0x40 */
+	__IO uint32_t UART_ICR;         /* Interrupt Clear Register 0x44 */
+	__IO uint32_t reserved4[14];
+	__IO uint32_t UART_TCR;       /* Test Control Register 0x48 */
+	__IO uint32_t UART_ITIP;
+	__IO uint32_t UART_ITOP;
+	__IO uint32_t UART_TDR;
+	__IO uint32_t reserved3[980];       /* Reserved 0x4c - 0cFDC */
+	__IO uint32_t UART_PeriphID0;   /* Peri. ID0 Register (0x11)                  Address offset: 0xFE0 */
+	__IO uint32_t UART_PeriphID1;   /* Peri. ID1 Register (0x10)                  Address offset: 0xFE4 */
+	__IO uint32_t UART_PeriphID2;   /* Peri. ID2 Register                         Address offset: 0xFE8 */
+	__IO uint32_t UART_PeriphID3;   /* Peri. ID3 Register (0x00)                  Address offset: 0xFEC */
+	__IO uint32_t UART_CellID0;     /* Cell ID0 Register  (0x0D)                  Address offset: 0xFF0 */
+	__IO uint32_t UART_CellID1;     /* Cell ID1 Register  (0xF0)                  Address offset: 0xFF4 */
+	__IO uint32_t UART_CellID2;     /* Cell ID2 Register  (0x05)                  Address offset: 0xFF8 */
+	__IO uint32_t UART_CellID3;     /* Cell ID3 Register  (0xB1)                  Address offset: 0xFFC */
+} UART_TypeDef;
+
+/*
+ * Pkfb
+ */
+typedef struct
+{
+  __IO uint32_t PKFB_FIFOCTRL;              /* PktFIFO Control Register 0x00 */
+  __IO uint32_t PKFB_FIFOSRAMCTRL0;         /* SRAM Test Control Register 0x04 */
+  __IO uint32_t PKFB_FIFOSRAMCTRL1;         /* SRAM Test Control Register,              Address offset: 0x08 */
+  __IO uint32_t PKFB_FIFOSTATUS;            /* FIFO Status Register,                    Address offset: 0x0C */
+  __IO uint32_t PKFB_PF0PUSHCTRL;           /* FIFO 0 Push Control,                     Address offset: 0x10 */
+  __IO uint32_t PKFB_PF0POPCTRL;            /* FIFO 0 Pop Control,                      Address offset: 0x14 */
+  __IO uint32_t PKFB_PF0CNT;                /* FIFO 0 Count,                            Address offset: 0x18 */
+  __IO uint32_t PKFB_PF0DATA;               /* FIFO 0 Push/Pop Data Register,           Address offset: 0x1C */
+  __IO uint32_t PKFB_PF1PUSHCTRL;           /* FIFO 1 Push Control,                     Address offset: 0x20 */
+  __IO uint32_t PKFB_PF1POPCTRL;            /* FIFO 1 Pop Control,                      Address offset: 0x24 */
+  __IO uint32_t PKFB_PF1CNT;                /* FIFO 1 Count,                            Address offset: 0x28 */
+  __IO uint32_t PKFB_PF1DATA;               /* FIFO 1 Push/Pop Data Register,           Address offset: 0x2C */
+  __IO uint32_t PKFB_PF2PUSHCTRL;           /* FIFO 2 Push Control,                     Address offset: 0x30 */
+  __IO uint32_t PKFB_PF2POPCTRL;            /* FIFO 2 Pop Control,                      Address offset: 0x34 */
+  __IO uint32_t PKFB_PF2CNT;                /* FIFO 2 Count,                            Address offset: 0x38 */
+  __IO uint32_t PKFB_PF2DATA;               /* FIFO 2 Push/Pop Data Register,           Address offset: 0x3C */
+  __IO uint32_t PKFB_PF8KPUSHCTRL;          /* FIFO 8K Push Control,                    Address offset: 0x40 */
+  __IO uint32_t PKFB_PF8KPOPCTRL;           /* FIFO 8K Pop Control,                     Address offset: 0x44 */
+  __IO uint32_t PKFB_PF8KCNT;               /* FIFO 8K Count,                           Address offset: 0x48 */
+  __IO uint32_t PKFB_PF8KDATA;              /* FIFO 8K Push/Pop Data Register,          Address offset: 0x4C */
+  __IO uint32_t PKFB_FIFO_COLL_INTR;        /* FIFO Collision Interrupt Register,       Address offset: 0x50 */
+  __IO uint32_t PKFB_FIFO_COLL_INTR_EN;     /* FIFO Collision Interrupt Enable Register Address offset: 0x54 */
+} PKFB_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t CLK_CTRL_A_0;			/* For Clock 1 & 10 0x00 */
+	__IO uint32_t CLK_CTRL_A_1;			/* 0x04 */
+	__IO uint32_t CLK_CTRL_B_0;			/* For Clock 2 0x08 */
+	__IO uint32_t reserved;				/* 0x0C */
+	__IO uint32_t CLK_CTRL_C_0;			/* For Clock 8 0x10 */
+	__IO uint32_t CLK_CTRL_D_0;			/* For Clock 11  0x14 */
+	__IO uint32_t CLK_CTRL_E_0;			/* For Clock 12  0x18 */
+	__IO uint32_t reserved1;
+	__IO uint32_t CLK_CTRL_F_0;			/* For Clock 16	0x20 */
+	__IO uint32_t CLK_CTRL_F_1;			/* 0x24 */
+	__IO uint32_t CLK_CTRL_G_0;			/* For Clock 18 0x28 */
+	__IO uint32_t CLK_CTRL_H_0;			/* For Clock 19 0x2C */
+	__IO uint32_t reserved2;
+	__IO uint32_t CLK_CTRL_I_0;			/* 0x34 */
+	__IO uint32_t CLK_CTRL_I_1;			/* 0x38 */
+	__IO uint32_t reverved3;			/* 0x3C */
+	__IO uint32_t C01_CLK_GATE;			/* 0x40 */
+	__IO uint32_t C02_CLK_GATE;			/* 0x44 */
+	__IO uint32_t C08_X4_CLK_GATE;		/* 0x48 */
+	__IO uint32_t C08_X1_CLK_GATE;		/* 0x4C */
+	__IO uint32_t C10_FCLK_GATE;			/* 0x50 */
+	__IO uint32_t C11_CLK_GATE;			/* 0x54 */
+	__IO uint32_t C12_CLK_GATE;			/* 0x58 */
+	__IO uint32_t CS_CLK_GATE;			/* 0x5C */
+	__IO uint32_t CU_CLK_GATE;			/* 0x60 */
+	__IO uint32_t C16_CLK_GATE;			/* 0x64 */
+	__IO uint32_t reversed4;			/* 0x68 */
+	__IO uint32_t C19_CLK_GATE;			/* 0x6C */
+	__IO uint32_t C21_CLK_GATE;			/* 0x70 */
+	__IO uint32_t reversed5[3];
+	__IO uint32_t PF_SW_RESET;			/* 0x80 */
+	__IO uint32_t FFE_SW_RESET;			/* 0x84 */
+	__IO uint32_t FB_SW_RESET;			/* 0x88 */
+	__IO uint32_t A1_SW_RESET;			/* 0x8C */
+	__IO uint32_t AUDIO_MISC_SW_RST;	/* 0x90 */
+	__IO uint32_t FB_MISC_SW_RST_CTL;	/* 0x94 */
+	__IO uint32_t reversed6[26];
+	__IO uint32_t CLK_CTRL_PMU;			/* 0x100 */
+	__IO uint32_t CRU_GENERAL;		    /* 0x104 */
+	__IO uint32_t CRU_DEBUG;			/* 0x108 */
+	__IO uint32_t reversed7[1];
+	__IO uint32_t C01_CLK_DIV;			/* 0x110 */
+	__IO uint32_t C09_CLK_DIV;			/* 0x114 */
+	__IO uint32_t C31_CLK_DIV;			/* 0x118 */
+	__IO uint32_t C09_CLK_GATE;			/* 0x11C */
+	__IO uint32_t C30_31_CLK_GATE;		/* 0x120 */
+	__IO uint32_t CLK_DIVIDER_CLK_GATING;	/* 0x124 */
+	__IO uint32_t reserved8[2];
+	__IO uint32_t CLK_SWITCH_FOR_B;
+	__IO uint32_t CLK_SWITCH_FOR_C;
+	__IO uint32_t CLK_SWITCH_FOR_D;
+	__IO uint32_t CLK_SWITCH_FOR_H;
+	__IO uint32_t CLK_SWITCH_FOR_J;
+	__IO uint32_t CLK_SWITCH_FOR_G;
+} CRU_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t MISC_POR_0;               /* 0x000 */
+	__IO uint32_t MISC_POR_1;               /* 0x004 */
+	__IO uint32_t MISC_POR_2;               /* 0x008 */
+	__IO uint32_t MISC_POR_3;               /* 0x00C */
+	__IO uint32_t RST_CTRL_0;               /* 0x010 */
+	__IO uint32_t RST_CTRL_1;               /* 0x014 */
+	__IO uint32_t CHIP_STA_0;               /* 0x018 */
+	__IO uint32_t CHIP_STA_1;               /* 0x01C */
+	__IO uint32_t WIC_CTRL;                 /* 0x020 */
+	__IO uint32_t WIC_STATUS;               /* 0x024 */
+	__IO uint32_t reserved[2];
+	__IO uint32_t PWR_DWN_SCH;              /* 0x030 */
+	__IO uint32_t reserved1[3];
+	__IO uint32_t PWR_OFF_OSC;              /* 0x040 */
+	__IO uint32_t EXT_WAKING_UP_SRC;        /* 0x044 */
+	__IO uint32_t reserved2[10];
+	__IO uint32_t SDMA_STATUS;              /* 0x070 */
+	__IO uint32_t SDMA_POWER_MODE_CFG;      /* 0x074 */
+	__IO uint32_t SDMA_PD_SRC_MASK_N;       /* 0x078 */
+	__IO uint32_t SDMA_WU_SRC_MASK_N;       /* 0x07C */
+	__IO uint32_t M4_STATUS;                /* 0x080 */
+	__IO uint32_t M4_PWR_MODE_CFG;          /* 0x084 */
+	__IO uint32_t M4_PD_SRC_MASK_N;         /* 0x088 */
+	__IO uint32_t M4_WU_SRC_MASK_N;         /* 0x08C */
+	__IO uint32_t FFE_STATUS;               /* 0x090 */
+	__IO uint32_t FFE_PWR_MODE_CFG;         /* 0x094 */
+	__IO uint32_t FFE_PD_SRC_MASK_N;        /* 0x098 */
+	__IO uint32_t FFE_WU_SRC_MASK_N;        /* 0x09C */
+	__IO uint32_t FB_STATUS;                /* 0x0A0 */
+	__IO uint32_t FB_PWR_MODE_CFG;          /* 0x0A4 */
+	__IO uint32_t FB_PD_SRC_MASK_N;         /* 0x0A8 */
+	__IO uint32_t FB_WU_SRC_MASK_N;         /* 0x0AC */
+	__IO uint32_t PF_STATUS;                /* 0x0B0 */
+	__IO uint32_t PF_PWR_MODE_CFG;          /* 0x0B4 */
+	__IO uint32_t PF_PD_SRC_MASK_N;         /* 0x0B8 */
+	__IO uint32_t PF_WU_SRC_MASK_N;         /* 0x0BC */
+	__IO uint32_t M4S0_SRAM_STATUS;         /* 0x0C0 */
+	__IO uint32_t M4S0_PWR_MODE_CFG;        /* 0x0C4 */
+	__IO uint32_t M4S0_PD_SRC_MASK_N;       /* 0x0C8 */
+	__IO uint32_t M4S0_WU_SRC_MASK_N;       /* 0x0CC */
+	__IO uint32_t A1_STATUS; 		        /* 0x0D0 */
+	__IO uint32_t A1_PWR_MODE_CFG;          /* 0x0D4 */
+	__IO uint32_t A1_PD_SRC_MASK_N;         /* 0x0D8 */
+	__IO uint32_t A1_WU_SRC_MASK_N;         /* 0x0DC */
+	__IO uint32_t MISC_STATUS;              /* 0x0E0 */
+	__IO uint32_t AUDIO_STATUS;             /* 0x0E4 */
+	__IO uint32_t M4_SRAM_STATUS;            /* 0x0E8 */
+	__IO uint32_t AUDIO_WU_SRC_MASK_N;      /* 0x0EC */
+	__IO uint32_t reserved3[4];
+	__IO uint32_t M4_MEM_CTRL_0;            /* 0x100 */
+	__IO uint32_t M4_MEM_CTRL_1;            /* 0x104 */
+	__IO uint32_t PF_MEM_CTRL_0;            /* 0x108 */
+	__IO uint32_t PF_MEM_CTRL_1;            /* 0x10C */
+	__IO uint32_t FFE_MEM_CTRL_0;           /* 0x110 */
+	__IO uint32_t FFE_MEM_CTRL_1;           /* 0x114 */
+	__IO uint32_t AUDIO_MEM_CTRL_0;         /* 0x118 */
+	__IO uint32_t AUDIO_MEM_CTRL_1;			/* 0x11C */
+	__IO uint32_t M4_MEM_CFG;				/* 0x120 */
+	__IO uint32_t PF_MEM_CFG;				/* 0x124 */
+	__IO uint32_t FFE_MEM_CFG;				/* 0x128 */
+	__IO uint32_t AUDIO_MEM_CFG;			/* 0x12C */
+	__IO uint32_t M4_MEM_CTRL_PWR_0;	/* 0x130 */
+	__IO uint32_t M4_MEM_CTRL_PWR_1;	/* 0x134 */
+	__IO uint32_t M4_MEM_CTRL_PWR_2;	/* 0x138 */
+	__IO uint32_t reserved4[1];
+	__IO uint32_t SDMA_MEM_CTRL_0;		/* 0x140 */
+	__IO uint32_t SDMA_MEM_CTRL_1;		/* 0x144 */
+	__IO uint32_t reserved5[14];
+	__IO uint32_t MEM_PWR_DOWN_CTRL;	/* 0x180 */
+	__IO uint32_t PMU_TIMER_CFG_0;		/* 0x184 */
+	__IO uint32_t PMU_TIMER_CFG_1;		/* 0x188 */
+	__IO uint32_t PDWU_TIMER_CFG;		/* 0x18C */
+	__IO uint32_t reserved6[28];
+	__IO uint32_t FFE_FB_PF_SW_PD;		/* 0x200 */
+	__IO uint32_t M4_SRAM_SW_PD;		/* 0x204 */
+	__IO uint32_t MISC_SW_PD;               /* 0x208 */
+	__IO uint32_t AUDIO_SW_PD;              /* 0x20C */
+	__IO uint32_t FFE_FB_PF_SW_WU;          /* 0x210 */
+	__IO uint32_t M4_SRAM_SW_WU;             /* 0x214 */
+	__IO uint32_t MISC_SW_WU;               /* 0x218 */
+	__IO uint32_t AUD_SRAM_SW_WU;		/* 0x21C */
+	__IO uint32_t PMU_STM_PRIORITY;         /* 0x220 */
+	__IO uint32_t reserved7[3];
+	__IO uint32_t M4SRAM_SSW_LPMF;			/* 0x230 */
+	__IO uint32_t M4SRAM_SSW_LPMH_MASK_N;	/* 0x234 */
+	__IO uint32_t reserved8[106];
+	__IO uint32_t EFUSE_BITS;    	      /* 0x3E0 */
+	__IO uint32_t reserved9[1];
+	__IO uint32_t FBVLPMinWidth;          /* 0x3E8 */
+	__IO uint32_t APRebootStatus;          /* 0x3EC */
+	__IO uint32_t GEN_PURPOSE_0;            /* 0x3F0 */
+	__IO uint32_t FB_ISOLATION;            /* 0x3F4 */
+	__IO uint32_t GEN_PURPOSE_1;			/* 0x3F8 */
+
+} PMU_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t ADDR;			/* 0x000 */
+	__IO uint32_t WDATA;			/* 0x004 */
+	__IO uint32_t CSR;				/* 0x008 */
+	__IO uint32_t RDATA;			/* 0x00C */
+	__IO uint32_t reserved0[1];		/* 0x010 */
+	__IO uint32_t SRAM_TEST_REG1;		/* 0x014 */
+	__IO uint32_t SRAM_TEST_REG2;		/* 0x018 */
+	__IO uint32_t reserved1[1];		/* 0x01C */
+	__IO uint32_t FFE_CSR;			/* 0x020 */
+	__IO uint32_t reserved2[5];		/* 0x024 */
+	__IO uint32_t FFE_DBG_COMBINED;		/* 0x038 */
+	__IO uint32_t reserved3[49];		/* 0x03C */
+	__IO uint32_t CMD;			/* 0x100 */
+	__IO uint32_t reserved4[1];		/* 0x104 */
+	__IO uint32_t INTERRUPT;		/* 0x108 */
+	__IO uint32_t INTERRUPT_EN;		/* 0x10C */
+	__IO uint32_t STATUS;			/* 0x110 */
+	__IO uint32_t MAILBOX_TO_FFE0;		/* 0x114 */
+	__IO uint32_t reserved5[2];		/* 0x118 */
+	__IO uint32_t SM_RUNTIME_ADDR;		/* 0x120 */
+	__IO uint32_t SM0_RUNTIME_ADDR_CTRL;	/* 0x124 */
+	__IO uint32_t SM1_RUNTIME_ADDR_CTRL;	/* 0x128 */
+	__IO uint32_t SM0_RUNTIME_ADDR_CUR;	/* 0x12C */
+	__IO uint32_t SM1_RUNTIME_ADDR_CUR;	/* 0x130 */
+	__IO uint32_t reserved6[3];		/* 0x134 */
+	__IO uint32_t SM0_DEBUG_SEL;		/* 0x140 */
+	__IO uint32_t SM1_DEBUG_SEL;		/* 0x144 */
+	__IO uint32_t FFE_DEBUG_SEL;		/* 0x148 */
+	__IO uint32_t reserved7[1];		/* 0x14C */
+	__IO uint32_t FFE0_BREAK_POINT_CFG;	/* 0x150 */
+	__IO uint32_t FFE0_BREAK_POINT_CONT;	/* 0x154 */
+	__IO uint32_t FFE0_BREAK_POINT_STAT;	/* 0x158 */
+	__IO uint32_t reserved8[1];		/* 0x15C */
+	__IO uint32_t FFE0_BP_XPC_0;		/* 0x160 */
+	__IO uint32_t FFE0_BP_XPC_1;		/* 0x164 */
+	__IO uint32_t FFE0_BP_XPC_2;		/* 0x168 */
+	__IO uint32_t FFE0_BP_XPC_3;		/* 0x16C */
+} EXT_REGS_FFE_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t DBG_MON;			/* 0x000 */
+	__IO uint32_t SUBSYS_DBG_MON_SEL;	/* 0x004 */
+	__IO uint32_t A0_DBG_MON_SEL;		/* 0x008 */
+	__IO uint32_t A0_PMU_DBG_MON_SEL;	/* 0x00C */
+	__IO uint32_t reserved1[60];		/* 0x010 */
+	__IO uint32_t IO_INPUT;			/* 0x100 */
+	__IO uint32_t IO_OUTPUT;		/* 0x104 */
+	__IO uint32_t reserved2[2];		/* 0x108 */
+	__IO uint32_t SW_MB_1;			/* 0x110 */
+	__IO uint32_t SW_MB_2;			/* 0x114 */
+	__IO uint32_t reserved3[58];		/* 0x118 */
+	__IO uint32_t PAD_SEL18;		/* 0x200 */
+	__IO uint32_t reserved4[3];		/* 0x204 */
+	__IO uint32_t CONFIG_MEM128_AON;	/* 0x210 */
+	__IO uint32_t reserved5[63];		/* 0x214 */
+	__IO uint32_t LOCK_KEY_CTRL;		/* 0x310 */
+	__IO uint32_t reserved6[58];		/* 0x314 */
+	__IO uint32_t FB_DEVICE_ID;		/* 0x3FC */
+} MISC_CTRL_BASE_TypeDef;
+
+/*
+ * IO MUX
+ */
+typedef struct
+{
+    __IO uint32_t PAD_0_CTRL;               /* PAD 0 Control 0x000 */
+    __IO uint32_t PAD_1_CTRL;               /* PAD 1 Control 0x004 */
+    __IO uint32_t PAD_2_CTRL;               /* PAD 2 Control 0x008 */
+    __IO uint32_t PAD_3_CTRL;               /* PAD 3 Control 0x00C */
+    __IO uint32_t PAD_4_CTRL;               /* PAD 4 Control 0x010 */
+    __IO uint32_t PAD_5_CTRL;               /* PAD 5 Control 0x014 */
+    __IO uint32_t PAD_6_CTRL;               /* PAD 6 Control 0x018 */
+    __IO uint32_t PAD_7_CTRL;               /* PAD 7 Control 0x01C */
+    __IO uint32_t PAD_8_CTRL;               /* PAD 8 Control 0x020 */
+    __IO uint32_t PAD_9_CTRL;               /* PAD 9 Control 0x024 */
+    __IO uint32_t PAD_10_CTRL;              /* PAD 10 Control 0x028 */
+    __IO uint32_t PAD_11_CTRL;              /* PAD 11 Control 0x02C */
+    __IO uint32_t PAD_12_CTRL;              /* PAD 12 Control 0x030 */
+    __IO uint32_t PAD_13_CTRL;              /* PAD 13 Control 0x034 */
+    __IO uint32_t PAD_14_CTRL;              /* PAD 14 Control 0x038 */
+    __IO uint32_t PAD_15_CTRL;              /* PAD 15 Control 0x03C */
+    __IO uint32_t PAD_16_CTRL;              /* PAD 16 Control 0x040 */
+    __IO uint32_t PAD_17_CTRL;              /* PAD 17 Control 0x044 */
+    __IO uint32_t PAD_18_CTRL;              /* PAD 18 Control 0x048 */
+    __IO uint32_t PAD_19_CTRL;              /* PAD 19 Control 0x04C */
+    __IO uint32_t PAD_20_CTRL;              /* PAD 20 Control 0x050 */
+    __IO uint32_t PAD_21_CTRL;              /* PAD 21 Control 0x054 */
+    __IO uint32_t PAD_22_CTRL;              /* PAD 22 Control 0x058 */
+    __IO uint32_t PAD_23_CTRL;              /* PAD 23 Control 0x05C */
+    __IO uint32_t PAD_24_CTRL;              /* PAD 24 Control 0x060 */
+    __IO uint32_t PAD_25_CTRL;              /* PAD 25 Control 0x064 */
+    __IO uint32_t PAD_26_CTRL;              /* PAD 26 Control 0x068 */
+    __IO uint32_t PAD_27_CTRL;              /* PAD 27 Control 0x06C */
+    __IO uint32_t PAD_28_CTRL;              /* PAD 28 Control 0x070 */
+    __IO uint32_t PAD_29_CTRL;              /* PAD 29 Control 0x074 */
+    __IO uint32_t PAD_30_CTRL;              /* PAD 30 Control 0x078 */
+    __IO uint32_t PAD_31_CTRL;              /* PAD 31 Control 0x07C */
+    __IO uint32_t PAD_32_CTRL;              /* PAD 32 Control 0x080 */
+    __IO uint32_t PAD_33_CTRL;              /* PAD 33 Control 0x084 */
+    __IO uint32_t PAD_34_CTRL;              /* PAD 34 Control 0x088 */
+    __IO uint32_t PAD_35_CTRL;              /* PAD 35 Control 0x08C */
+    __IO uint32_t PAD_36_CTRL;              /* PAD 36 Control 0x090 */
+    __IO uint32_t PAD_37_CTRL;              /* PAD 37 Control 0x094 */
+    __IO uint32_t PAD_38_CTRL;              /* PAD 38 Control 0x098 */
+    __IO uint32_t PAD_39_CTRL;              /* PAD 39 Control 0x09C */
+    __IO uint32_t PAD_40_CTRL;              /* PAD 40 Control 0x0A0 */
+    __IO uint32_t PAD_41_CTRL;              /* PAD 41 Control 0x0A4 */
+    __IO uint32_t PAD_42_CTRL;              /* PAD 42 Control 0x0A8 */
+    __IO uint32_t PAD_43_CTRL;              /* PAD 43 Control 0x0AC */
+    __IO uint32_t PAD_44_CTRL;              /* PAD 44 Control 0x0B0 */
+    __IO uint32_t PAD_45_CTRL;              /* PAD 45 Control 0x0B4 */
+    __IO uint32_t reserved1[18];
+    __IO uint32_t SDA0_SEL_REG;                 /* Address offset: 0x100 */
+    __IO uint32_t SDA1_SEL_REG;                 /* Address offset: 0x104 */
+    __IO uint32_t SDA2_SEL_REG;                 /* Address offset: 0x108 */
+    __IO uint32_t SCL0_SEL_REG;                 /* Address offset: 0x10C */
+    __IO uint32_t SCL1_SEL_REG;                 /* Address offset: 0x110 */
+    __IO uint32_t SCL2_SEL_REG;                 /* Address offset: 0x114 */
+    __IO uint32_t SPIs_CLK_SEL;             /* Address offset: 0x118 */
+    __IO uint32_t SPIs_SSn_SEL;             /* Address offset: 0x11C */
+    __IO uint32_t SPIs_MOSI_SEL;            /* Address offset: 0x120 */
+    __IO uint32_t SPIm_MISO_SEL;            /* Address offset: 0x124 */
+    __IO uint32_t PDM_DATA_SELE;             /* Address offset: 0x128 */
+    __IO uint32_t I2S_DATA_SELECT;             /* Address offset: 0x12C */
+    __IO uint32_t reserved2[1];
+    __IO uint32_t UART_rxd_SEL;             /* Address offset: 0x134 */
+    __IO uint32_t IrDA_Sirin_SEL;           /* Address offset: 0x138 */
+    __IO uint32_t S_INTR_0_SEL_REG;             /* Address offset: 0x13C */
+    __IO uint32_t S_INTR_1_SEL_REG;             /* Address offset: 0x140 */
+    __IO uint32_t S_INTR_2_SEL_REG;             /* Address offset: 0x144 */
+    __IO uint32_t S_INTR_3_SEL_REG;             /* Address offset: 0x148 */
+    __IO uint32_t S_INTR_4_SEL_REG;             /* Address offset: 0x14C */
+    __IO uint32_t S_INTR_5_SEL_REG;             /* Address offset: 0x150 */
+    __IO uint32_t S_INTR_6_SEL_REG;             /* Address offset: 0x154 */
+    __IO uint32_t S_INTR_7_SEL_REG;             /* Address offset: 0x158 */
+    __IO uint32_t NUARTCTS_SEL;             /* Address offset: 0x15C */
+    __IO uint32_t IO_REG_SEL_REG;               /* Address offset: 0x160 */
+    __IO uint32_t reserved3[3];
+    __IO uint32_t SW_CLK_SEL;               /* Address offset: 0x170 */
+    __IO uint32_t SW_IO_SEL;                /* Address offset: 0x174 */
+    __IO uint32_t reserved4[2];
+    __IO uint32_t FBIO_SEL_1_REG;                 /* Address offset: 0x180 */
+    __IO uint32_t FBIO_SEL_2_REG;                 /* Address offset: 0x184 */
+    __IO uint32_t reserved5[2];
+    __IO uint32_t SPI_SENSOR_MISO_SEL;	/* Address offset: 0x190 */
+    __IO uint32_t SPI_SENSOR_MOSI_SEL;	/* Address offset: 0x194 */
+    __IO uint32_t reserved6[2];
+    __IO uint32_t I2S_WD_CLKIN_SEL;	/* Address offset: 0x1A0 */
+    __IO uint32_t I2S_CLKIN_SEL;	/* Address offset: 0x1A4 */
+    __IO uint32_t PDM_STAT_IN_SEL;	/* Address offset: 0x1A8 */
+    __IO uint32_t PDM_CLKIN_SEL;	/* Address offset: 0x1AC */
+} IO_MUX_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t SPT_CFG;
+	__IO uint32_t SLEEP_MODE;
+	__IO uint32_t ERR_CMP_40M;
+	__IO uint32_t ERR_CMP_1S_0;
+	__IO uint32_t ERR_CMP_1S_1;
+	__IO uint32_t ERR_CMP_1S_2;
+	__IO uint32_t ERR_CMP_1S_3;
+	__IO uint32_t ERR_CMP_RTC_0;
+	__IO uint32_t ERR_CMP_RTC_1;
+	__IO uint32_t ERR_CMP_RTC_2;
+	__IO uint32_t ERR_CMP_RTC_3;
+	__IO uint32_t UPDATE_TMR_VAL;
+	__IO uint32_t SPARE_BITS;
+	__IO uint32_t TIMER_VAL;
+	__IO uint32_t EVENT_CNT_VAL;
+	__IO uint32_t MS_CNT_VAL;
+
+}SPT_REGS_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t GPIO_INTR;                /* Address offset: 0x00 */
+    __IO uint32_t GPIO_INTR_RAW;            /* Address offset: 0x04 */
+    __IO uint32_t GPIO_INTR_TYPE;           /* Address offset: 0x08 */
+    __IO uint32_t GPIO_INTR_POL;            /* Address offset: 0x0C */
+    __IO uint32_t GPIO_INTR_EN_AP;          /* Address offset: 0x10 */
+    __IO uint32_t GPIO_INTR_EN_M4;          /* Address offset: 0x14 */
+    __IO uint32_t GPIO_INTR_EN_FFE0;        /* Address offset: 0x18 */
+    __IO uint32_t GPIO_INTR_EN_FFE1;        /* Address offset: 0x1C */
+    __IO uint32_t reserved1[4];
+    __IO uint32_t OTHER_INTR;               /* Address offset: 0x30 */
+    __IO uint32_t OTHER_INTR_EN_AP;         /* Address offset: 0x34 */
+    __IO uint32_t OTHER_INTR_EN_M4;         /* Address offset: 0x38 */
+    __IO uint32_t reserved2[1];
+    __IO uint32_t SOFTWARE_INTR_1;          /* Address offset: 0x40 */
+    __IO uint32_t SOFTWARE_INTR_1_EN_AP;    /* Address offset: 0x44 */
+    __IO uint32_t SOFTWARE_INTR_1_EN_M4;    /* Address offset: 0x48 */
+    __IO uint32_t reserved3[1];
+    __IO uint32_t SOFTWARE_INTR_2;          /* Address offset: 0x50 */
+    __IO uint32_t SOFTWARE_INTR_2_EN_AP;    /* Address offset: 0x54 */
+    __IO uint32_t SOFTWARE_INTR_2_EN_M4;    /* Address offset: 0x58 */
+    __IO uint32_t reserved4[1];
+    __IO uint32_t FFE_INTR;                 /* Address offset: 0x60 */
+    __IO uint32_t FFE_INTR_EN_AP;           /* Address offset: 0x64 */
+    __IO uint32_t FFE_INTR_EN_M4;           /* Address offset: 0x68 */
+    __IO uint32_t reserved5[1];
+    __IO uint32_t FFE1_FB_INTR;             /* Address offset: 0x70 */
+    __IO uint32_t FFE1_FB_INTR_EN_AP;       /* Address offset: 0x74 */
+    __IO uint32_t FFE1_FB_INTR_EN_M4;       /* Address offset: 0x78 */
+    __IO uint32_t reserved6[1];
+    __IO uint32_t FB_INTR;                  /* Address offset: 0x80 */
+    __IO uint32_t FB_INTR_RAW;              /* Address offset: 0x84 */
+    __IO uint32_t FB_INTR_TYPE;             /* Address offset: 0x88 */
+    __IO uint32_t FB_INTR_POL;              /* Address offset: 0x8C */
+    __IO uint32_t FB_INTR_EN_AP;            /* Address offset: 0x90 */
+    __IO uint32_t FB_INTR_EN_M4;            /* Address offset: 0x94 */
+    __IO uint32_t reserved7[2];
+    __IO uint32_t M4_MEM_AON_INTR;	/* Address offset: 0xA0 */
+    __IO uint32_t M4_MEM_AON_INTR_EN;	/* Address offset: 0xA4 */
+} INTR_CTRL_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t CTRLR0;                   /* Control Register #0,                               Address offset: 0x00 */
+    __IO uint32_t CTRLR1;                   /* Control Register #1,                               Address offset: 0x04 */
+    __IO uint32_t SSIENR;                   /* SSI Enable Register,                               Address offset: 0x08 */
+    __IO uint32_t reserved1;
+    __IO uint32_t SER;                      /* Slave Enable Register,                             Address offset: 0x10 */
+    __IO uint32_t BAUDR;                    /* Baud Rate Register,                                Address offset: 0x14 */
+    __IO uint32_t TXFTLR;                   /* Tx FIFO Threshold Register,                        Address offset: 0x18 */
+    __IO uint32_t RXFTLR;                   /* Rx FIFO Threshold Register,                        Address offset: 0x1C */
+    __IO uint32_t TXFLR;                    /* Tx FIFO Level Register,                            Address offset: 0x20 */
+    __IO uint32_t RXFLR;                    /* Rx FIFO Level Register,                            Address offset: 0x24 */
+    __IO uint32_t SR;                       /* Status Register,                                   Address offset: 0x28 */
+    __IO uint32_t IMR;                      /* Interrupt Mask Register,                           Address offset: 0x2C */
+    __IO uint32_t ISR;                      /* Interrupt Status Register,                         Address offset: 0x30 */
+    __IO uint32_t RISR;                     /* Interrupt Raw Status Register,                     Address offset: 0x34 */
+    __IO uint32_t TXOICR;                   /* Tx FIFO Overflow Interrupt Clear Register,         Address offset: 0x38 */
+    __IO uint32_t RXOICR;                   /* Rx FIFO Overflow Interrupt Clear Register,         Address offset: 0x3C */
+    __IO uint32_t RXUICR;                   /* Rx FIFO Underflow Interrupt Clear Register,        Address offset: 0x40 */
+    __IO uint32_t MSTICR;                   /* Multi-Master Contention Interrupt Clear Register,  Address offset: 0x44 */
+    __IO uint32_t ICR;                      /* Interrupt Clear Register,                          Address offset: 0x48 */
+    __IO uint32_t reserved2[3];
+    __IO uint32_t IDR;
+    __IO uint32_t SSI_COMP_VERSION;
+    __IO uint32_t DR0;                      /* Data Register,                                     Address offset: 0x60 */
+} SPI_TypeDef;
+
+
+typedef struct
+{
+    __IO uint32_t IER;			/* I2S Enable Register 0x00 */
+    __IO uint32_t reserved1[1];
+    __IO uint32_t ITER;			/* Tx block enable 0x008 */
+    __IO uint32_t reserved2[3];
+    __IO uint32_t TXFFR;		/* Tx block fifo reset reg 0x018 */
+    __IO uint32_t reserved3[1];
+    __IO uint32_t LTHR0;		/* Left tx holding reg 0x020 */
+    __IO uint32_t RTHR0;		/* Right tx holding reg 0x020 */
+    __IO uint32_t reserved4[1];
+    __IO uint32_t TER0;			/* Tx enable reg 0x02C */
+    __IO uint32_t reserved5[1];
+    __IO uint32_t TCR0;			/* Tx config reg 0x034 */
+    __IO uint32_t ISR0;			/* Intr status reg 0x038 */
+    __IO uint32_t IMR0;			/* Intr mask reg 0x03C */
+    __IO uint32_t reserved6[1];
+    __IO uint32_t TOR0;			/* Tx overrun reg 0x044 */
+    __IO uint32_t reserved7[1];
+    __IO uint32_t TFCR0;		/* Tx fifo config reg 0x04C */
+    __IO uint32_t reserved8[1];
+    __IO uint32_t TFF0;			/* Tx fifo flush reg 0x054 */
+    __IO uint32_t reserved9[92];
+    __IO uint32_t TXDMA;		/* Tx block dma reg 0x1C8 */
+    __IO uint32_t RTXDMA;		/* Reset Tx block dma reg 0x1CC */
+    __IO uint32_t reserved10[9];
+    __IO uint32_t I2S_COMP_PARAM_1;	/* Component parm reg 0x1F4 */
+    __IO uint32_t I2S_COMP_VERSION;	/* Component version reg 0x1F8 */
+    __IO uint32_t I2S_COMP_TYPE;	/* Component type reg 0x1FC */
+    __IO uint32_t resereved11[126];
+    __IO uint32_t I2S_STEREO_EN;	/* Stereo enable reg 0x3F8 */
+} I2S_TypeDef;
+
+// Naveen - Aud Block definition according to tamar2 register spec available @ ${SVN_URL}/svn/Platform/Tamar2/Design/ASSP/doc/tamar2_regs.xlsx
+typedef struct {
+	__IO uint32_t VOICE_CONFIG;				// 0x000
+	__IO uint32_t LPSD_CONFIG;					// 0x004
+	__IO uint32_t VOICE_DMAC_CONFIG;			// 0x008
+	__IO uint32_t VOICE_DMAC_LEN;				// 0x00C
+	__IO uint32_t VOICE_DMAC_FIFO;				// 0x010
+	__IO uint32_t VOICE_DMAC_DST_ADDR0;		// 0x014
+	__IO uint32_t VOICE_DMAC_DST_ADDR1;		// 0x018
+	__IO uint32_t PDM_CORE_CONFIG;				// 0x01C
+	__IO uint32_t VOICE_STATUS;				// 0x020
+	__IO uint32_t I2S_CONFIG;					// 0x024
+
+} AUD_TypeDef;
+
+
+typedef struct
+{
+	__IO uint32_t DMA_CTRL;		/* DMA Control Register 0x00 */
+	__IO uint32_t DMA_DEST_ADDR;	/* DMA Destination Address 0x04 */
+	__IO uint32_t DMA_XFER_CNT;	/* DMA Transfer Count 0x08 */
+	__IO uint32_t CFG_FLASH_HEADER;	/* CFG FLASH Header 0x0C */
+	__IO uint32_t DMA_INTR;		/* DMA Interrupt Register 0x10 */
+	__IO uint32_t DMA_INTR_MASK;	/* DMA Interrupt Mask Register 0x14 */
+} DMA_SPI_MS_TypeDef;
+
+
+/*
+ * System DMA
+ */
+typedef struct
+{
+    __IO uint32_t SRC_DATA_END_PTR_CH0;      /* Ptr to the end address of the source of Ch0    Address offset: 0x00 */
+    __IO uint32_t DST_DATA_END_PTR_CH0;      /* Ptr to the end address of the dest of Ch0      Address offset: 0x04 */
+    __IO uint32_t CH_CFG_CH0;                /* Configuration of Ch0                           Address offset: 0x08 */
+    __IO uint32_t reserved0[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH1;      /* Ptr to the end address of the source of Ch1    Address offset: 0x10 */
+    __IO uint32_t DST_DATA_END_PTR_CH1;      /* Ptr to the end address of the dest of Ch1      Address offset: 0x14 */
+    __IO uint32_t CH_CFG_CH1;                /* Configuration of Ch1                           Address offset: 0x18 */
+    __IO uint32_t reserved1[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH2;      /* Ptr to the end address of the source of Ch2    Address offset: 0x20 */
+    __IO uint32_t DST_DATA_END_PTR_CH2;      /* Ptr to the end address of the dest of Ch2      Address offset: 0x24 */
+    __IO uint32_t CH_CFG_CH2;                /* Configuration of Ch2                           Address offset: 0x28 */
+    __IO uint32_t reserved2[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH3;      /* Ptr to the end address of the source of Ch3    Address offset: 0x30 */
+    __IO uint32_t DST_DATA_END_PTR_CH3;      /* Ptr to the end address of the dest of Ch3      Address offset: 0x34 */
+    __IO uint32_t CH_CFG_CH3;                /* Configuration of Ch3                           Address offset: 0x38 */
+    __IO uint32_t reserved3[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH4;      /* Ptr to the end address of the source of Ch4    Address offset: 0x40 */
+    __IO uint32_t DST_DATA_END_PTR_CH4;      /* Ptr to the end address of the dest of Ch4      Address offset: 0x44 */
+    __IO uint32_t CH_CFG_CH4;                /* Configuration of Ch4                           Address offset: 0x48 */
+    __IO uint32_t reserved4[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH5;      /* Ptr to the end address of the source of Ch5    Address offset: 0x50 */
+    __IO uint32_t DST_DATA_END_PTR_CH5;      /* Ptr to the end address of the dest of Ch5      Address offset: 0x54 */
+    __IO uint32_t CH_CFG_CH5;                /* Configuration of Ch5                           Address offset: 0x58 */
+    __IO uint32_t reserved5[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH6;      /* Ptr to the end address of the source of Ch6    Address offset: 0x60 */
+    __IO uint32_t DST_DATA_END_PTR_CH6;      /* Ptr to the end address of the dest of Ch6      Address offset: 0x64 */
+    __IO uint32_t CH_CFG_CH6;                /* Configuration of Ch6                           Address offset: 0x68 */
+    __IO uint32_t reserved6[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH7;      /* Ptr to the end address of the source of Ch7    Address offset: 0x70 */
+    __IO uint32_t DST_DATA_END_PTR_CH7;      /* Ptr to the end address of the dest of Ch7      Address offset: 0x74 */
+    __IO uint32_t CH_CFG_CH7;                /* Configuration of Ch7                           Address offset: 0x78 */
+    __IO uint32_t reserved7[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH8;      /* Ptr to the end address of the source of Ch8    Address offset: 0x80 */
+    __IO uint32_t DST_DATA_END_PTR_CH8;      /* Ptr to the end address of the dest of Ch8      Address offset: 0x84 */
+    __IO uint32_t CH_CFG_CH8;                /* Configuration of Ch8                           Address offset: 0x88 */
+    __IO uint32_t reserved8[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH9;      /* Ptr to the end address of the source of Ch9    Address offset: 0x90 */
+    __IO uint32_t DST_DATA_END_PTR_CH9;      /* Ptr to the end address of the dest of Ch9      Address offset: 0x94 */
+    __IO uint32_t CH_CFG_CH9;                /* Configuration of Ch9                           Address offset: 0x98 */
+    __IO uint32_t reserved9[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH10;     /* Ptr to the end address of the source of Ch10   Address offset: 0xA0 */
+    __IO uint32_t DST_DATA_END_PTR_CH10;     /* Ptr to the end address of the dest of Ch10     Address offset: 0xA4 */
+    __IO uint32_t CH_CFG_CH10;               /* Configuration of Ch10                          Address offset: 0xA8 */
+    __IO uint32_t reserved10[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH11;     /* Ptr to the end address of the source of Ch11   Address offset: 0xB0 */
+    __IO uint32_t DST_DATA_END_PTR_CH11;     /* Ptr to the end address of the dest of Ch11     Address offset: 0xB4 */
+    __IO uint32_t CH_CFG_CH11;               /* Configuration of Ch11                          Address offset: 0xB8 */
+    __IO uint32_t reserved11[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH12;     /* Ptr to the end address of the source of Ch12   Address offset: 0xC0 */
+    __IO uint32_t DST_DATA_END_PTR_CH12;     /* Ptr to the end address of the dest of Ch12     Address offset: 0xC4 */
+    __IO uint32_t CH_CFG_CH12;               /* Configuration of Ch12                          Address offset: 0xC8 */
+    __IO uint32_t reserved12[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH13;     /* Ptr to the end address of the source of Ch13   Address offset: 0xD0 */
+    __IO uint32_t DST_DATA_END_PTR_CH13;     /* Ptr to the end address of the dest of Ch13     Address offset: 0xD4 */
+    __IO uint32_t CH_CFG_CH13;               /* Configuration of Ch13                          Address offset: 0xD8 */
+    __IO uint32_t reserved13[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH14;     /* Ptr to the end address of the source of Ch14   Address offset: 0xE0 */
+    __IO uint32_t DST_DATA_END_PTR_CH14;     /* Ptr to the end address of the dest of Ch14     Address offset: 0xE4 */
+    __IO uint32_t CH_CFG_CH14;               /* Configuration of Ch14                          Address offset: 0xE8 */
+    __IO uint32_t reserved14[1];
+    __IO uint32_t SRC_DATA_END_PTR_CH15;     /* Ptr to the end address of the source of Ch15   Address offset: 0xF0 */
+    __IO uint32_t DST_DATA_END_PTR_CH15;     /* Ptr to the end address of the dest of Ch15     Address offset: 0xF4 */
+    __IO uint32_t CH_CFG_CH15;               /* Configuration of Ch15                          Address offset: 0xF8 */
+    __IO uint32_t reserved15[1];
+    __IO uint32_t ALT_SRC_DATA_END_PTR_CH0;
+    __IO uint32_t ALT_DST_DATA_END_PTR_CH0;
+    __IO uint32_t ALT_CHN_CFG_CH0;
+    __IO uint32_t resereved16[1];
+    __IO uint32_t ALT_SRC_DATA_END_PTR_CH1;
+    __IO uint32_t ALT_DST_DATA_END_PTR_CH1;
+    __IO uint32_t ALT_CHN_CFG_CH1;
+    __IO uint32_t resereved17[1];
+    __IO uint32_t ALT_SRC_DATA_END_PTR_CH2;
+    __IO uint32_t ALT_DST_DATA_END_PTR_CH2;
+    __IO uint32_t ALT_CHN_CFG_CH2;
+    __IO uint32_t resereved18[1];
+    __IO uint32_t ALT_SRC_DATA_END_PTR_CH3;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH3;
+	__IO uint32_t ALT_CHN_CFG_CH3;
+	__IO uint32_t resereved19[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH4;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH4;
+	__IO uint32_t ALT_CHN_CFG_CH4;
+	__IO uint32_t resereved20[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH5;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH5;
+	__IO uint32_t ALT_CHN_CFG_CH5;
+	__IO uint32_t resereved21[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH6;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH6;
+	__IO uint32_t ALT_CHN_CFG_CH6;
+	__IO uint32_t resereved22[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH7;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH7;
+	__IO uint32_t ALT_CHN_CFG_CH7;
+	__IO uint32_t resereved23[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH8;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH8;
+	__IO uint32_t ALT_CHN_CFG_CH8;
+	__IO uint32_t resereved24[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH9;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH9;
+	__IO uint32_t ALT_CHN_CFG_CH9;
+	__IO uint32_t resereved25[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH10;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH10;
+	__IO uint32_t ALT_CHN_CFG_CH10;
+	__IO uint32_t resereved26[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH11;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH11;
+	__IO uint32_t ALT_CHN_CFG_CH11;
+	__IO uint32_t resereved27[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH12;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH12;
+	__IO uint32_t ALT_CHN_CFG_CH12;
+	__IO uint32_t resereved28[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH13;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH13;
+	__IO uint32_t ALT_CHN_CFG_CH13;
+	__IO uint32_t resereved29[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH14;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH14;
+	__IO uint32_t ALT_CHN_CFG_CH14;
+	__IO uint32_t resereved30[1];
+	__IO uint32_t ALT_SRC_DATA_END_PTR_CH15;
+	__IO uint32_t ALT_DST_DATA_END_PTR_CH15;
+
+}SDMA_SRAM_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t SRC_DATA_END_PTR;      /* Ptr to the end address of the source */
+    __IO uint32_t DST_DATA_END_PTR;      /* Ptr to the end address of the dest   */
+    __IO uint32_t CH_CFG;                /* Configuration of Ch0                 */
+    uint32_t reserved0;
+}SDMA_SRAM_ENTRY_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t DMA_REQ;                   /* Dma Request                                    Address offset: 0x00 */
+    __IO uint32_t DMA_WAITONREQ_REG;
+    __IO uint32_t DMA_ACTIVE_REG;
+    __IO uint32_t SDMA_PWRDN_CNT;
+    __IO uint32_t SDMA_SRAM_CTRL;
+}SDMA_BRIDGE_TypeDef;
+
+typedef struct
+{
+    __IO uint32_t DMA_STATUS;                /* Dma status                                     Address offset: 0x00 */
+    __IO uint32_t DMA_CFG;                   /* Dma configuration                              Address offset: 0x04 */
+    __IO uint32_t CTRL_BASE_PTR;             /* Control base pointer                           Address offset: 0x08 */
+    __IO uint32_t ALT_CTRL_BASE_PTR;         /* Alt. Control base pointer                      Address offset: 0x0C */
+    __IO uint32_t DMA_WAITONREQ_STATUS;      /* Channel wait on req status                     Address offset: 0x10 */
+    __IO uint32_t CHNL_SW_REQ;               /* Channel switch req                             Address offset: 0x14 */
+    __IO uint32_t CHNL_USEBURST_SET;         /* Channel burst set                              Address offset: 0x18 */
+    __IO uint32_t CHNL_USEBURST_CLR;         /* Channel burst clear                            Address offset: 0x1C */
+    __IO uint32_t CHNL_REQ_MASK_SET;         /* Channel req mask set                           Address offset: 0x20 */
+    __IO uint32_t CHNL_REQ_MASK_CLR;         /* Channel req mask clear                         Address offset: 0x24 */
+    __IO uint32_t CHNL_ENABLE_SET;           /* Channel enable set                             Address offset: 0x28 */
+    __IO uint32_t CHNL_ENABLE_CLR;           /* Channel enable clear                           Address offset: 0x2C */
+    __IO uint32_t CHNL_PRI_ALT_SET;          /* Channel primary alt set                        Address offset: 0x30 */
+    __IO uint32_t CHNL_PRI_ALT_CLR;          /* Channel primary alt clear                      Address offset: 0x34 */
+    __IO uint32_t CHNL_PRIORITY_SET;         /* Channel priority set                           Address offset: 0x38 */
+    __IO uint32_t CHNL_PRIORITY_CLR;         /* Channel priority clear                         Address offset: 0x3C */
+    __IO uint32_t reserved0[3];
+    __IO uint32_t ERR_CLR;                   /* Clear error                                    Address offset: 0x4C */
+    __IO uint32_t reserved1[995];
+    __IO uint32_t PERIPH_ID_4;               /* Peripheral identification 4                    Address offset: 0xFD0 */
+    __IO uint32_t reserved2[3];
+    __IO uint32_t PERIPH_ID_0;               /* Peripheral identification 0                    Address offset: 0xFE0 */
+    __IO uint32_t PERIPH_ID_1;               /* Peripheral identification 1                    Address offset: 0xFE4 */
+    __IO uint32_t PERIPH_ID_2;               /* Peripheral identification 2                    Address offset: 0xFE8 */
+    __IO uint32_t PERIPH_ID_3;               /* Peripheral identification 3                    Address offset: 0xFEC */
+    __IO uint32_t PCELL_ID_0;                /* PrimeCell  identification 0                    Address offset: 0xFF0 */
+    __IO uint32_t PCELL_ID_1;                /* PrimeCell  identification 1                    Address offset: 0xFF4 */
+    __IO uint32_t PCELL_ID_2;                /* PrimeCell  identification 2                    Address offset: 0xFF8 */
+    __IO uint32_t PCELL_ID_3;                /* PrimeCell  identification 3                    Address offset: 0xFFC */
+
+} SDMA_TypeDef;
+
+// i2s slave typedef
+typedef struct
+{
+    __IO uint32_t IER;		                // i2s enable register - offset 0x0
+    __IO uint32_t reserved0;					// hole - offset: 0x04
+    __IO uint32_t ITER;						// i2s transmitter block enable register - offset:0x8
+    __IO uint32_t reserved1[3];					// holes - offset: 0x0C
+    __IO uint32_t TXFFR;					// transmitter block fifo reset register - offset: 0x18
+    __IO uint32_t reserved2;				// offset: 0x1c
+    __IO uint32_t LTHR0;					// left transmit holding register - offset: 0x20
+    __IO uint32_t RTHR0;					// right transmit holding register - offset: 0x24
+    __IO uint32_t reserved3;					// hole - offset: 0x28
+    __IO uint32_t TER0;						// transmit enable register - offset: 0x2C
+    __IO uint32_t reserved4;					// hole - offset: 0x30
+    __IO uint32_t TCR0;						// transmit configuration register - offset: 0x34
+    __IO uint32_t ISR0;						// interrupt status register - offset: 0x38
+    __IO uint32_t IMR0;						// interrupt mask register - offset: 0x3C
+    __IO uint32_t reserved5;					// hole - offset: 0x40
+    __IO uint32_t TOR0;						// transmit overrun register - offset: 0x44
+    __IO uint32_t reserved6;					// hole - offset: 0x48
+    __IO uint32_t TFCR0;					// transmit fifo configuration register - offset: 0x4C
+    __IO uint32_t reserved7;					// hole - offset 0x50
+    __IO uint32_t TFFO;						// transmit fifo flush - offset: 0x54
+    __IO uint32_t reserved8[92];				// holes - offset: 0x58
+    __IO uint32_t TXDMA;					// transmit block dma register - offset: 0x1C8
+    __IO uint32_t RTXDMA;					// reset transmit block dma register - offset: 0x1CC
+    __IO uint32_t reserved9[9];					// holes - offset: 0x1D0
+    __IO uint32_t I2S_COMP_PARAM_1;			// component parameter register 1 - offset: 0x1F4
+    __IO uint32_t I2S_COMP_VERSION;			// offset: 0x1F8
+	__IO uint32_t I2S_COMP_TYPE;			// offset: 0x1FC
+	__IO uint32_t hole9[126];				// holes - offset 0x200
+	__IO uint32_t I2S_STEREO_EN;			// i2s stereo enable register - offset: 0x3F8
+} I2S_SLAVE_TypeDef;
+
+/*
+ * External Interrupt/Event Controller
+ */
+
+typedef struct
+{
+  __IO uint32_t IMR;    /*!< EXTI Interrupt mask register,            Address offset: 0x00 */
+  __IO uint32_t EMR;    /*!< EXTI Event mask register,                Address offset: 0x04 */
+  __IO uint32_t RTSR;   /*!< EXTI Rising trigger selection register,  Address offset: 0x08 */
+  __IO uint32_t FTSR;   /*!< EXTI Falling trigger selection register, Address offset: 0x0C */
+  __IO uint32_t SWIER;  /*!< EXTI Software interrupt event register,  Address offset: 0x10 */
+  __IO uint32_t PR;     /*!< EXTI Pending register,                   Address offset: 0x14 */
+} EXTI_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t reserved;			/* Address offset: 0x00 */
+	__IO uint32_t RTC_CTRL_1;		/* Address offset: 0x04 */
+	__IO uint32_t RTC_CTRL_2;		/* Address offset: 0x08 */
+	__IO uint32_t RTC_CTRL_3;		/* Address offset: 0x0C */
+	__IO uint32_t RTC_CTRL_4;		/* Address offset: 0x10 */
+	__IO uint32_t RTC_CTRL_5;		/* Address offset: 0x14 */
+	__IO uint32_t RTC_CTRL_6;		/* Address offset: 0x18 */
+	__IO uint32_t RTC_CTRL_7;		/* Address offset: 0x1C */
+	__IO uint32_t RTC_STA_0;		/* Address offset: 0x20 */
+	__IO uint32_t RTC_STA_1;		/* Address offset: 0x24 */
+	__IO uint32_t reserved1[22];
+	__IO uint32_t OSC_CTRL_0;		/* Address offset: 0x80 */
+	__IO uint32_t OSC_CTRL_1;		/* Address offset: 0x84 */
+	__IO uint32_t OSC_CTRL_2;		/* Address offset: 0x88 */
+	__IO uint32_t OSC_CTRL_3;		/* Address offset: 0x8C */
+	__IO uint32_t OSC_CTRL_4;		/* Address offset: 0x90 */
+	__IO uint32_t OSC_CTRL_5;		/* Address offset: 0x94 */
+	__IO uint32_t OSC_CTRL_6;		/* Address offset: 0x98 */
+	__IO uint32_t OSC_CTRL_7;		/* Address offset: 0x9C */
+	__IO uint32_t OSC_STA_0;		/* Address offset: 0xA0 */
+	__IO uint32_t OSC_STA_1;		/* Address offset: 0xA4 */
+	__IO uint32_t reserved2[22];
+	__IO uint32_t APC_CTRL_0;		/* Address offset: 0x100 */
+	__IO uint32_t APC_CTRL_1;		/* Address offset: 0x104 */
+	__IO uint32_t APC_CTRL_2;		/* Address offset: 0x108 */
+	__IO uint32_t APC_CTRL_3;		/* Address offset: 0x10C */
+	__IO uint32_t APC_CTRL_4;		/* Address offset: 0x110 */
+	__IO uint32_t APC_CTRL_5;		/* Address offset: 0x114 */
+	__IO uint32_t APC_CTRL_6;		/* Address offset: 0x118 */
+	__IO uint32_t APC_CTRL_7;		/* Address offset: 0x11C */
+	__IO uint32_t APC_STA_0;		/* Address offset: 0x120 */
+	__IO uint32_t APC_STA_1;		/* Address offset: 0x124 */
+	__IO uint32_t reserved3[22];
+	__IO uint32_t RING_OSC;			/* Address offset: 0x180 */
+	__IO uint32_t reserved4[31];
+	__IO uint32_t LD0_30_CTRL_0;
+	__IO uint32_t LD0_30_CTRL_1;
+	__IO uint32_t reserved5[2];
+	__IO uint32_t LD0_50_CTRL_0;
+	__IO uint32_t LD0_50_CTRL_1;
+}AIP_Typedef;
+
+/*
+ * Watchdog timer
+ */
+typedef struct
+{
+  __IO uint32_t WDOGLOAD;                    /* WDOG Load Register                                     Address offset: 0x00 */
+  __IO uint32_t WDOGVALUE;                   /* WDOG Current Value Register                            Address offset: 0x04 */
+  __IO uint32_t WDOGCONTROL;                 /* WDOG Control Register                                  Address offset: 0x08 */
+  __IO uint32_t WDOGINTCLR;                  /* WDOG Clear Int Register                                Address offset: 0x0C */
+  __IO uint32_t WDOGRIS;                     /* WDOG Raw Int Status Register                           Address offset: 0x10 */
+  __IO uint32_t WDOGMIS;                     /* WDOG Masked Int Status Register                        Address offset: 0x14 */
+  __IO uint32_t reserved1[762];
+  __IO uint32_t WDOGLOCK;                    /* WDOG Disable Write Register                            Address offset: 0xC00 */
+  __IO uint32_t reserved2[191];
+  __IO uint32_t WDOGITCR;                    /* WDOG Enable Integration Test Register                  Address offset: 0xF00 */
+  __IO uint32_t WDOGITOP;                    /* WDOG Integration Test Output Register                  Address offset: 0xF00 */
+  uint32_t reserved3[50];
+  __IO uint32_t WDOGPERIPHID4;               /* WDOG Peripheral ID Register 4                          Address offset: 0xFD0 */
+  __IO uint32_t WDOGPERIPHID5;               /* WDOG Peripheral ID Register 5                          Address offset: 0xFD4 */
+  __IO uint32_t WDOGPERIPHID6;               /* WDOG Peripheral ID Register 6                          Address offset: 0xFD8 */
+  __IO uint32_t WDOGPERIPHID7;               /* WDOG Peripheral ID Register 7                          Address offset: 0xFDC */
+  __IO uint32_t WDOGPERIPHID0;               /* WDOG Peripheral ID Register 0                          Address offset: 0xFE0 */
+  __IO uint32_t WDOGPERIPHID1;               /* WDOG Peripheral ID Register 1                          Address offset: 0xFE4 */
+  __IO uint32_t WDOGPERIPHID2;               /* WDOG Peripheral ID Register 2                          Address offset: 0xFE8 */
+  __IO uint32_t WDOGPERIPHID3;               /* WDOG Peripheral ID Register 3                          Address offset: 0xFEC */
+  __IO uint32_t WDOGPCELLID0;                /* WDOG Component ID Register 0                           Address offset: 0xFF0 */
+  __IO uint32_t WDOGPCELLID1;                /* WDOG Component ID Register 1                           Address offset: 0xFF4 */
+  __IO uint32_t WDOGPCELLID2;                /* WDOG Component ID Register 2                           Address offset: 0xFF8 */
+  __IO uint32_t WDOGPCELLID3;                /* WDOG Component ID Register 3                           Address offset: 0xFFC */
+} WDT_TypeDef;
+
+/*
+ * CWM Batching Type Define
+ */
+
+ typedef struct
+{
+    __IO uint8_t TAG; /* Data Address: 0x00 */
+    __IO uint8_t WRITE_POS;
+    __IO uint8_t HDR_RESERVED0[2];
+    __IO uint8_t READ_POS;
+    __IO uint8_t HDR_RESERVED1[3];
+    __IO uint8_t HDR_RESERVED2[120];
+    __IO uint8_t DATA0[128];		/* Data Address: 0x80 */
+    __IO uint8_t DATA1[128];		/* Data Address: 0x100 */
+    __IO uint8_t DATA2[128];		/* Data Address: 0x180 */
+    __IO uint8_t DATA3[128];		/* Data Address: 0x200 */
+    __IO uint8_t DATA4[128];		/* Data Address: 0x280 */
+    __IO uint8_t DATA5[128];		/* Data Address: 0x300 */
+    __IO uint8_t DATA6[128];		/* Data Address: 0x380 */
+} BATCHING_TypeDef;
+
+typedef struct
+{
+    __IO uint8_t DATA[16]; /* Data Address: 0x00 */
+} RECV_DATA_TypeDef;
+
+
+typedef struct
+{
+	__IO uint32_t CTRL;
+	__IO uint32_t VALUE;
+	__IO uint32_t RELOAD;
+	__IO uint32_t INTSTATUS_INTCLEAR;
+	__IO uint32_t reserved[1008];
+	__IO uint32_t PID4;
+	__IO uint32_t PID5;
+	__IO uint32_t PID6;
+	__IO uint32_t PID7;
+	__IO uint32_t PID0;
+	__IO uint32_t PID1;
+	__IO uint32_t PID2;
+	__IO uint32_t PID3;
+	__IO uint32_t CID0;
+	__IO uint32_t CID1;
+	__IO uint32_t CID2;
+	__IO uint32_t CID3;
+}TIMER_TypeDef;
+
+/*
+ * FPGA GPIO
+ */
+typedef struct
+{
+  	__IO uint32_t ID_VALUE;
+	__IO uint32_t REV_LEVEL;
+	__IO uint32_t GPIO_INPUT;
+	__IO uint32_t GPIO_OUTPUT;
+	__IO uint32_t GPIO_DIR_CTRL;
+}FPGA_GPIO_TypeDef;
+
+typedef struct
+{
+	__IO uint32_t UART_DR_DLLSB;    /* Receive/Transmit/DL_LSB: 0x00 */
+	__IO uint32_t UART_IER_DLMSB;   /* Interrupt Enable Register/DL_MSB: 0x04 */
+	__IO uint32_t UART_IIR_FCR;     /* Interrupt Identification Register, FIFO Control Register 0x08 */
+	__IO uint32_t UART_LCR;         /* Line Control Register 0xC */
+	__IO uint32_t UART_MCR;         /* Modem Control Register 0x10 */
+	__IO uint32_t UART_LSR;         /* Line Status Register 0x14 */
+	__IO uint32_t UART_MSR;         /* Modem Status Register 0x18 */
+	__IO uint32_t UART_SR;          /* Scratch Register 0x1C */
+} FPGA_UART_TypeDef;
+
+/**
+  * @brief Peripheral_memory_map
+  */
+#define SRAM1_BASE            ((uint32_t)0x20000000) /*!< SRAM1(128 KB) base address */
+#define SRAM2_BASE            ((uint32_t)0x20020000) /*!< SRAM2(128 KB) base address */
+#define SRAM3_BASE            ((uint32_t)0x20040000) /*!< SRAM3(128 KB) base address */
+
+/* Legacy defines */
+#define SRAM_BASE             SRAM1_BASE
+
+/*!< Peripheral memory map */
+#define PERIPH_BASE           (0x40000000)
+#define AON_PERIPH_BASE       (PERIPH_BASE)
+#define APB0_PERIPH_BASE      (PERIPH_BASE + 0x00010000)
+#define FPGA_PERIPH_BASE      (PERIPH_BASE + 0x00020000)
+#define FFE_PERIPH_BASE       (PERIPH_BASE + 0x00040000)
+
+/* Bit bang memory map */
+#define BB_BASE		      (0x42000000)
+#define AON_BB_BASE	      (BB_BASE)
+#define APB0_BB_BASE          (BB_BASE + 0x00200000)
+#define FPGA_BB_BASE          (BB_BASE + 0x00400000)
+#define FFE_BB_BASE           (BB_BASE + 0x00800000)
+
+/* AON peripherals */
+#define PKFB_BASE             (AON_PERIPH_BASE+0x2000)
+#define CRU_BASE              (AON_PERIPH_BASE+0x4000)
+#define PMU_BASE              (AON_PERIPH_BASE+0x4400)
+#define INTR_CTRL_BASE        (AON_PERIPH_BASE+0x4800)
+#define IO_MUX_BASE           (AON_PERIPH_BASE+0x4C00)
+#define MISC_CTRL_BASE        (AON_PERIPH_BASE+0x5000)
+#define AIP_BASE              (AON_PERIPH_BASE+0x5400)
+#define JTM_BASE              (AON_PERIPH_BASE+0x5A00)
+#define SPT_BASE	      (AON_PERIPH_BASE+0x5C00)
+#define A1_REG_BASE           (AON_PERIPH_BASE+0x6000)
+#define SPI_MS_BASE           (AON_PERIPH_BASE+0x7000)
+#define DMA_SPI_MS_BASE       (AON_PERIPH_BASE+0x7400)
+#define I2S_BASE              (AON_PERIPH_BASE+0x8000)
+#define I2S_SLAVE_BASE        (AON_PERIPH_BASE+0xB000)
+#define SDMA_BASE             (AON_PERIPH_BASE+0xC000)
+#define SDMA_BRIDGE_BASE      (AON_PERIPH_BASE+0xD000)
+#define SDMA_SRAM_BASE        (AON_PERIPH_BASE+0xF000)
+
+/* APB0 peripherals */
+#define UART_BASE	      (APB0_PERIPH_BASE)
+#define WDT1_BASE             (APB0_PERIPH_BASE+0x2000)
+#define TIMER1_BASE           (APB0_PERIPH_BASE+0x3000)
+#define PIF_CTRL_BASE         (APB0_PERIPH_BASE+0x4000)
+#define AUD_BASE              (APB0_PERIPH_BASE+0x5000)
+#define RAM_FIFO0_BASE        (APB0_PERIPH_BASE+0x8000)
+#define RAM_FIFO1_BASE        (APB0_PERIPH_BASE+0x9000)
+#define RAM_FIFO2_BASE        (APB0_PERIPH_BASE+0xA000)
+#define RAM_FIFO3_BASE        (APB0_PERIPH_BASE+0xB000)
+
+/* FFE peripherals */
+#define DM0_BASE	      (FFE_PERIPH_BASE)
+#define SM0_BASE	      (FFE_PERIPH_BASE+0x04000)
+#define SM1_BASE	      (FFE_PERIPH_BASE+0x08000)
+#define EXT_REGS_FFE_BASE     (FFE_PERIPH_BASE+0x0A000)
+#define DM_FFE1_BASE	      (FFE_PERIPH_BASE+0x0C000)
+#define CM_BASE	              (FFE_PERIPH_BASE+0x10000)
+
+/* M4 Internal Registers */
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           ((uint32_t )0xE0042000)
+
+#define FB_GPIO_BASE	       FPGA_PERIPH_BASE
+#define FB_UART_BASE          (FPGA_PERIPH_BASE+0x1000)
+
+/* IR register definitions */
+#define FB_IR_DEVID_REG					(FPGA_PERIPH_BASE+(0x800)+(0x50<<2))	//	(FPGA_PERIPH_BASE+(0x50<<2))
+
+/*
+ * Peripheral_declaration
+ */
+
+#define UART			((UART_TypeDef *)UART_BASE)
+#define PKFB			((PKFB_TypeDef *)PKFB_BASE)
+#define IO_MUX			((IO_MUX_TypeDef *)IO_MUX_BASE)
+#define INTR_CTRL		((INTR_CTRL_TypeDef *)INTR_CTRL_BASE)
+#define SPI_MS			((SPI_TypeDef *) SPI_MS_BASE)
+#define I2S				((I2S_TypeDef *) I2S_BASE)
+#define AUD				((AUD_TypeDef *) AUD_BASE)
+#define CRU				((CRU_TypeDef *) CRU_BASE)
+#define PMU				((PMU_TypeDef *) PMU_BASE)
+#define MISC_CTRL		((MISC_CTRL_BASE_TypeDef *)MISC_CTRL_BASE)
+#define WDT				((WDT_TypeDef *) WDT1_BASE)
+#define DMA_SPI_MS		((DMA_SPI_MS_TypeDef *) DMA_SPI_MS_BASE)
+#define I2S_SLAVE		((I2S_SLAVE_TypeDef *)I2S_SLAVE_BASE)
+#define SDMA			((SDMA_TypeDef *) SDMA_BASE)
+#define SDMA_BRIDGE    	((SDMA_BRIDGE_TypeDef *) SDMA_BRIDGE_BASE)
+#define SDMA_SRAM_TAB	((SDMA_SRAM_ENTRY_TypeDef *) SDMA_SRAM_BASE)
+#define EXT_REGS_FFE	((EXT_REGS_FFE_TypeDef *)EXT_REGS_FFE_BASE)
+#define AIP				((AIP_Typedef*)AIP_BASE)
+#define SPT				((SPT_REGS_TypeDef *)SPT_BASE)
+#define FB_GPIO		((FPGA_GPIO_TypeDef *)FB_GPIO_BASE)
+#define FB_UART         ((FPGA_UART_TypeDef *)FB_UART_BASE)
+#define FB_I2C          ((FPGA_I2C_TypeDef *)FB_I2C_BASE)
+#define FB_HRM		((FPGA_HRM_TypeDef *)FB_HRM_BASE)
+#define TIMER		((TIMER_TypeDef *)TIMER1_BASE)
+#define SHM_QL_BASE                   (0x2007C000)
+
+/******************************************************************************
+ * 				FFE                                           *
+ ******************************************************************************/
+#define FFE_CMD_RUN_FFE0_ONCE		((uint32_t) (0x00000001))
+#define FFE_CMD_RUN_FFE1		((uint32_t) (0x00000002))
+#define FFE_CMD_RUN_SM0_ONCE		((uint32_t) (0x00000004))
+#define FFE_CMD_RUN_SM1_ONCE		((uint32_t) (0x00000008))
+
+#define FFE_INTR_SM_MULT_WR_INTR	((uint32_t) (0x00000001))
+#define FFE_INTR_FFE0_OVERRUN		((uint32_t) (0x00000002))
+#define FFE_INTR_FFE1_SM1_OVERRUN	((uint32_t) (0x00000004))
+#define FFE_INTR_FFE1_SM0_OVERRUN	((uint32_t) (0x00000008))
+#define FFE_INTR_FFE0_SM1_OVERRUN	((uint32_t) (0x00000010))
+#define FFE_INTR_FFE0_SM0_OVERRUN	((uint32_t) (0x00000020))
+#define FFE_INTR_I2C_MS_1_ERROR		((uint32_t) (0x00000040))
+#define FFE_INTR_I2C_MS_0_ERROR		((uint32_t) (0x00000080))
+#define FFE_INTR_CM0_LP_INTR		((uint32_t) (0x00000100))
+#define FFE_INTR_DM0_LP_INTR		((uint32_t) (0x00000200))
+#define FFE_INTR_DM1_LP_INTR		((uint32_t) (0x00000400))
+#define FFE_INTR_SM0_LP_INTR		((uint32_t) (0x00000800))
+#define FFE_INTR_SM1_LP_INTR		((uint32_t) (0x00001000))
+#define FFE_INTR_FFE0_BP_MATCH_INTR	((uint32_t) (0x00002000))
+#define FFE_INTR_FFE1_OVERRUN		((uint32_t) (0x00004000))
+#define FFE_INTR_PKFB_OVF_INTR		((uint32_t) (0x00008000))
+
+#define FFE_SMO_BUSY			((uint32_t) (0x00000001))
+#define FFE_SM1_BUSY			((uint32_t) (0x00000002))
+#define FFE_FFEO_BUSY			((uint32_t) (0x00000004))
+#define FFE_FFE1_BUSY			((uint32_t) (0x00000008))
+#define FFE_FFEO_BG_FLAG		((uint32_t) (0x00000010))
+#define FFE_FFE0_FG_FLAG		((uint32_t) (0x00000020))
+/******************************************************************************
+ * 				MISC                                          *
+ ******************************************************************************/
+#define MISC_RUN_FFE_CNT		((uint32_t) (0x00000001))
+#define MISC_FFE_START_PERIOD_LATCH_EN	((uint32_t) (0x00000002))
+#define MISC_PMU_START_PERIOD_LATCH_EN	((uint32_t) (0x00000004))
+#define MISC_FFE_KICKOFF_MODE		((uint32_t) (0x00000008))
+#define MISC_FFE_SPT_EN 		((uint32_t) (0x00000010))
+#define MISC_FFE_SLEEP_MODE		((uint32_t) (0x00000020))
+#define MISC_RUN_FFE_CONT_ASYNC		((uint32_t) (0x00000100))
+#define MISC_FFE_KICKOFF_MODE_ASYNC	((uint32_t) (0x00000800))
+#define MISC_FFE_SPT_EN_ASYNC		((uint32_t) (0x00001000))
+#define MISC_FFE_SLEEP_MODE_ASYNC	((uint32_t) (0x00002000))
+
+/******************************************************************************
+ *                                   UART                                     *
+ ******************************************************************************/
+
+/* Bit definition for data register */
+#define UART_DR_OVERRUN_ERR				  	  ((uint32_t) (1 << 11))
+#define UART_DR_BREAK_ERR                     ((uint32_t) (1 << 10))
+#define UART_DR_PARITY_ERR                    ((uint32_t) (1 << 9))
+#define UART_DR_FRAMING_ERR                   ((uint32_t) (1 << 8))
+#define UART_DR_DATA                          ((uint32_t) (0xFF))
+
+/* Bit definition for rx status register */
+#define UART_RSR_OVERRUN_ERR                  ((uint32_t) (1 << 3))
+#define UART_RSR_BREAK_ERR                    ((uint32_t) (1 << 2))
+#define UART_RSR_PARITY_ERR                   ((uint32_t) (1 << 1))
+#define UART_RSR_FRAMING_ERR                  ((uint32_t) (1 << 0))
+
+/* Bit definition for flag register */
+#define UART_TFR_RING_INDICATOR               ((uint32_t) (1 << 8))
+#define UART_TFR_TX_FIFO_EMPTY                ((uint32_t) (1 << 7))
+#define UART_TFR_RX_FIFO_FULL                 ((uint32_t) (1 << 6))
+#define UART_TFR_TX_FIFO_FULL                 ((uint32_t) (1 << 5))
+#define UART_TFR_RX_FIFO_EMPTY                ((uint32_t) (1 << 4))
+#define UART_TFR_BUSY                         ((uint32_t) (1 << 3))
+#define UART_TFR_DATA_CARRY_DETECT            ((uint32_t) (1 << 2))
+#define UART_TFR_DATA_SET_RDY                 ((uint32_t) (1 << 1))
+#define UART_TFR_CLEAR_TO_SEND                ((uint32_t) (1 << 0))
+
+/* Bit definition for IrDA low power counter register */
+#define UART_ILPR_LOW_POWER_DIVISOR           ((uint32_t) (0xFF))
+
+/* Bit definition for integer baud rate register */
+#define UART_IBRD_BAUD_INT_DIVISOR            ((uint32_t) (0xFFFF))
+
+
+/* Bit definition for fractional baud rate register */
+#define UART_IBRD_BAUD_FRACT_DIVISOR          ((uint32_t) (0x1F))
+
+/* Bit definition for line control register */
+#define UART_LCR_STICK_PARITY_SELECT          ((uint32_t) (0x80))
+#define UART_LCR_WLEN_8_BITS                  ((uint32_t) (0x60))
+#define UART_LCR_WLEN_7_BITS                  ((uint32_t) (0x40))
+#define UART_LCR_WLEN_6_BITS                  ((uint32_t) (0x20))
+#define UART_LCR_WLEN_5_BITS                  ((uint32_t) (0x00))
+#define UART_LCR_ENABLE_FIFO                  ((uint32_t) (0x10))
+#define UART_LCR_TWO_STOP_BITS                ((uint32_t) (0x08))
+#define UART_LCR_EVEN_PARITY                  ((uint32_t) (0x04))
+#define UART_LCR_ODD_PARITY                   ((uint32_t) (0x00))
+#define UART_LCR_PARITY_ENABLE                ((uint32_t) (0x02))
+#define UART_LCR_SEND_BREAK                   ((uint32_t) (0x01))
+
+/* Bit definition for control register */
+#define UART_CR_CTS_ENABLE	                  ((uint32_t) (0x8000))
+#define UART_CR_RTS_ENABLE	                  ((uint32_t) (0x4000))
+#define UART_CR_OUT2	                      ((uint32_t) (0x2000))
+#define UART_CR_OUT1	                      ((uint32_t) (0x1000))
+#define UART_CR_RTS	                          ((uint32_t) (0x0800))
+#define UART_CR_DTR  	                      ((uint32_t) (0x0400))
+#define UART_CR_RX_ENABLE                     ((uint32_t) (0x0200))
+#define UART_CR_TX_ENABLE                     ((uint32_t) (0x0100))
+#define UART_CR_LOOPBACK_ENABLE               ((uint32_t) (0x0080))
+#define UART_CR_SIR_LOWPOWER                  ((uint32_t) (0x0004))
+#define UART_CR_SIR_ENABLE                    ((uint32_t) (0x0002))
+#define UART_CR_UART_ENABLE                   ((uint32_t) (0x0001))
+
+/* Bit definition for interrupt FIFO level select register */
+#define UART_IFLS_RX_1_8_FULL                 ((uint32_t) (0x0000))
+#define UART_IFLS_RX_1_4_FULL                 ((uint32_t) (0x0008))
+#define UART_IFLS_RX_1_2_FULL                 ((uint32_t) (0x0010))
+#define UART_IFLS_RX_3_4_FULL                 ((uint32_t) (0x0018))
+#define UART_IFLS_RX_7_8_FULL                 ((uint32_t) (0x0020))
+#define UART_IFLS_TX_1_8_FULL                 ((uint32_t) (0x0000))
+#define UART_IFLS_TX_1_4_FULL                 ((uint32_t) (0x0001))
+#define UART_IFLS_TX_1_2_FULL                 ((uint32_t) (0x0002))
+#define UART_IFLS_TX_3_4_FULL                 ((uint32_t) (0x0003))
+#define UART_IFLS_TX_7_8_FULL                 ((uint32_t) (0x0004))
+
+/* Bit definition for interrupt mask set/clear register */
+#define UART_IMSC_OVERRUN_ERR                 ((uint32_t) (0x0400))
+#define UART_IMSC_BREAK_ERR                   ((uint32_t) (0x0200))
+#define UART_IMSC_PARITY_ERR                  ((uint32_t) (0x0100))
+#define UART_IMSC_FRAMING_ERR                 ((uint32_t) (0x0080))
+#define UART_IMSC_RX_TIMEOUT                  ((uint32_t) (0x0040))
+#define UART_IMSC_TX                          ((uint32_t) (0x0020))
+#define UART_IMSC_RX                          ((uint32_t) (0x0010))
+#define UART_IMSC_DSR                         ((uint32_t) (0x0008))
+#define UART_IMSC_DCD                         ((uint32_t) (0x0004))
+#define UART_IMSC_CTS                         ((uint32_t) (0x0002))
+#define UART_IMSC_RI                          ((uint32_t) (0x0001))
+
+/* Bit definition for raw interrupt status register */
+#define UART_RIS_OVERRUN_ERR                  ((uint32_t) (0x0400))
+#define UART_RIS_BREAK_ERR                    ((uint32_t) (0x0200))
+#define UART_RIS_PARITY_ERR                   ((uint32_t) (0x0100))
+#define UART_RIS_FRAMING_ERR                  ((uint32_t) (0x0080))
+#define UART_RIS_RX_TIMEOUT                   ((uint32_t) (0x0040))
+#define UART_RIS_TX                           ((uint32_t) (0x0020))
+#define UART_RIS_RX                           ((uint32_t) (0x0010))
+#define UART_RIS_DSR                          ((uint32_t) (0x0008))
+#define UART_RIS_DCD                          ((uint32_t) (0x0004))
+#define UART_RIS_CTS                          ((uint32_t) (0x0002))
+#define UART_RIS_RI                           ((uint32_t) (0x0001))
+
+/* Bit definition for masked interrupt status register */
+#define UART_MIS_OVERRUN_ERR                  ((uint32_t) (0x0400))
+#define UART_MIS_BREAK_ERR                    ((uint32_t) (0x0200))
+#define UART_MIS_PARITY_ERR                   ((uint32_t) (0x0100))
+#define UART_MIS_FRAMING_ERR                  ((uint32_t) (0x0080))
+#define UART_MIS_RX_TIMEOUT                   ((uint32_t) (0x0040))
+#define UART_MIS_TX                           ((uint32_t) (0x0020))
+#define UART_MIS_RX                           ((uint32_t) (0x0010))
+#define UART_MIS_DSR                          ((uint32_t) (0x0008))
+#define UART_MIS_DCD                          ((uint32_t) (0x0004))
+#define UART_MIS_CTS                          ((uint32_t) (0x0002))
+#define UART_MIS_RI                           ((uint32_t) (0x0001))
+
+/* Bit definition for interrupt clear register */
+#define UART_IC_OVERRUN_ERR                  ((uint32_t) (0x0400))
+#define UART_IC_BREAK_ERR                    ((uint32_t) (0x0200))
+#define UART_IC_PARITY_ERR                   ((uint32_t) (0x0100))
+#define UART_IC_FRAMING_ERR                  ((uint32_t) (0x0080))
+#define UART_IC_RX_TIMEOUT                   ((uint32_t) (0x0040))
+#define UART_IC_TX                           ((uint32_t) (0x0020))
+#define UART_IC_RX                           ((uint32_t) (0x0010))
+#define UART_IC_DSR                          ((uint32_t) (0x0008))
+#define UART_IC_DCD                          ((uint32_t) (0x0004))
+#define UART_IC_CTS                          ((uint32_t) (0x0002))
+#define UART_IC_RI                           ((uint32_t) (0x0001))
+
+/* Bit definition for dma control register */
+#define UART_DMACR_ON_ERR                    ((uint32_t) (0x0004))
+#define UART_DMACR_TX_DMA_ENABLE             ((uint32_t) (0x0002))
+#define UART_DMACR_RX_DMA_ENABLE             ((uint32_t) (0x0001))
+
+/******************************************************************************
+ *                                   WDT                                      *
+ ******************************************************************************/
+#define WDOG_CTRL_RESEN                  ((uint32_t) (0x0002))
+#define WDOG_CTRL_INTEN                  ((uint32_t) (0x0001))
+
+/******************************************************************************
+ *                                   DMA                                      *
+ ******************************************************************************/
+#define	DMA_CTRL_START_BIT		 ((uint32_t) (0x00000001))
+#define DMA_CTRL_STOP_BIT		 ((uint32_t) (0x00000002))
+#define DMA_CTRL_AHB_SEL_BIT		 ((uint32_t) (0x00000004))
+
+#define DMA_INTR_HERROR			 ((uint32_t) (0x00000001))
+#define DMA_INTR_RX_DATA_AVAIL		 ((uint32_t) (0x00000002))
+#define DMA_INTR_AHB_BRIDGE_FIFO_OFL	 ((uint32_t) (0x00000004))
+
+#define DMA_HERROR_INTR_MSK		 ((uint32_t) (0x00000001))
+#define DMA_RX_DATA_AVAIL_INTR_MSK	 ((uint32_t) (0x00000002))
+#define DMA_AHB_FIFO_OFL_INTR_MSK	 ((uint32_t) (0x00000004))
+
+/******************************************************************************
+ *                                   PKFB                                     *
+ ******************************************************************************/
+
+/* Bit definition for FIFO control register */
+#define FIFO_CTRL_PF_ENABLE                 ((uint32_t) (0x00000001))
+#define FIFO_CTRL_PF_PUSH_MUX_FFE           ((uint32_t) (0x00000002))
+#define FIFO_CTRL_PF_PUSH_MUX_M4            ((uint32_t) (0x00000000))
+#define FIFO_CTRL_PF_POP_MUX_AP             ((uint32_t) (0x00000004))
+#define FIFO_CTRL_PF_POP_MUX_M4             ((uint32_t) (0x00000000))
+#define FIFO_CTRL_PF_PUSH_INT_MUX_AP        ((uint32_t) (0x00000008))
+#define FIFO_CTRL_PF_PUSH_INT_MUX_M4        ((uint32_t) (0x00000000))
+#define FIFO_CTRL_PF_POP_INT_MUX_AP         ((uint32_t) (0x00000010))
+#define FIFO_CTRL_PF_POP_INT_MUX_M4         ((uint32_t) (0x00000000))
+#define FIFO_CTRL_PF_FFE_SEL_FFE1           ((uint32_t) (0x00000020))
+#define FIFO_CTRL_PF_FFE_SEL_FFE0           ((uint32_t) (0x00000000))
+
+#define FIFO_CTRL_PF0_SHIFT                  (0)
+#define FIFO_CTRL_PF1_SHIFT					 (8)
+#define FIFO_CTRL_PF2_SHIFT                  (16)
+#define FIFO_CTRL_PF8K_SHIFT                 (24)
+
+#define FIFO_SRAM_CTRL_PF_TEST1A_ENABLE           ((uint32_t) (0x00000000))
+#define FIFO_SRAM_CTRL_PF_TEST1A_DISABLE          ((uint32_t) (0x00000001))
+#define FIFO_SRAM_CTRL_PF_RMEA_ENABLE             ((uint32_t) (0x00000000))
+#define FIFO_SRAM_CTRL_PF_RMEA_DISABLE            ((uint32_t) (0x00000002))
+#define FIFO_SRAM_CTRL_PF_RMA_MASK                ((uint32_t) (0x0000003C))
+#define FIFO_SRAM_CTRL_PF_TEST1B_ENABLE           ((uint32_t) (0x00000000))
+#define FIFO_SRAM_CTRL_PF_TEST1B_DISABLE          ((uint32_t) (0x00000100))
+#define FIFO_SRAM_CTRL_PF_RMEB_ENABLE             ((uint32_t) (0x00000000))
+#define FIFO_SRAM_CTRL_PF_RMEB_DISABLE            ((uint32_t) (0x00000200))
+#define FIFO_SRAM_CTRL_PF_RMB_MASK                ((uint32_t) (0x00003C00))
+
+#define FIFO_SRAM_CTRL0_PF0_SHIFT 			(0)
+#define FIFO_SRAM_CTRL0_PF1_SHIFT           (16)
+#define FIFO_SRAM_CTRL1_PF2_SHIFT           (0)
+#define FIFO_SRAM_CTRL1_PF8K_SHIFT          (16)
+
+#define FIFO_STATUS_PF_SRAM_SLEEP_ACTIVE            ((uint32_t) (0x00000000))
+#define FIFO_STATUS_PF_SRAM_SLEEP_LIGHT             ((uint32_t) (0x00000001))
+#define FIFO_STATUS_PF_SRAM_SLEEP_DEEP              ((uint32_t) (0x00000002))
+#define FIFO_STATUS_PF_SRAM_SLEEP_SHUTDOWN          ((uint32_t) (0x00000003))
+#define FIFO_STATUS_PF_PUSH_INT_OVER                ((uint32_t) (0x00000004))
+#define FIFO_STATUS_PF_PUSH_INT_THRESH              ((uint32_t) (0x00000008))
+#define FIFO_STATUS_PF_PUSH_INT_SLEEP               ((uint32_t) (0x00000010))
+#define FIFO_STATUS_PF_POP_INT_UNDER                ((uint32_t) (0x00000020))
+#define FIFO_STATUS_PF_POP_INT_THRESH               ((uint32_t) (0x00000040))
+#define FIFO_STATUS_PF_POP_INT_SLEEP                ((uint32_t) (0x00000080))
+
+#define FIFO_STATUS_PF0_SHIFT				(0)
+#define FIFO_STATUS_PF1_SHIFT				(8)
+#define FIFO_STATUS_PF2_SHIFT				(16)
+#define FIFO_STATUS_PF8K_SHIFT				(24)
+
+#define PF_PUSH_CTRL_SLEEP_EN_ACTIVE                 ((uint32_t) (0x00000001))
+#define PF_PUSH_CTRL_SLEEP_TYPE_SD                   ((uint32_t) (0x00000002))
+#define PF_PUSH_CTRL_SLEEP_TYPE_DS                   ((uint32_t) (0x00000000))
+#define PF_PUSH_CTRL_INT_EN_MASK                     ((uint32_t) (0x00000000))
+#define PF_PUSH_CTRL_INT_EN_OVER                     ((uint32_t) (0x00000004))
+#define PF_PUSH_CTRL_INT_EN_THRES                    ((uint32_t) (0x00000008))
+#define PF_PUSH_CTRL_INT_EN_PUSH_ON_SLEEP            ((uint32_t) (0x00000010))
+#define PF_PUSH_CTRL_PUSH_THRESH_MASK                ((uint32_t) (0x01FF0000))
+
+#define PF_POP_CTRL_SLEEP_EN_ACTIVE                  ((uint32_t) (0x00000001))
+#define PF_POP_CTRL_SLEEP_TYPE_SD                    ((uint32_t) (0x00000002))
+#define PF_POP_CTRL_SLEEP_TYPE_DS                    ((uint32_t) (0x00000000))
+#define PF_POP_CTRL_INT_EN_MASK                      ((uint32_t) (0x00000000))
+#define PF_POP_CTRL_INT_EN_UNDER                     ((uint32_t) (0x00000004))
+#define PF_POP_CTRL_INT_EN_THRES                     ((uint32_t) (0x00000008))
+#define PF_POP_CTRL_INT_EN_POP_ON_SLEEP              ((uint32_t) (0x00000010))
+#define PF_POP_CTRL_PUSH_THRESH_MASK                 ((uint32_t) (0x01FF0000))
+
+#define PF_CNT_POP_CNT_MASK                          ((uint32_t) (0x000001FF))
+#define PF_CNT_POP_EMPTY_MASK                        ((uint32_t) (0x00008000))
+#define PF_CNT_PUSH_CNT_MASK                         ((uint32_t) (0x01FF0000))
+#define PF_CNT_PUSH_EMPTY_MASK                       ((uint32_t) (0x80000000))
+
+#define PF8K_DATA_REG_PUSH_EOP                         ((uint32_t) (0x00020000))
+
+#define FIFO_COLL_INTR_PF_COLL_INTR                   ((uint32_t) (0x00000001))
+
+#define FIFO_COLL_INTR_PF0_SHIFT		(0)
+#define FIFO_COLL_INTR_PF1_SHIFT		(1)
+#define FIFO_COLL_INTR_PF2_SHIFT		(2)
+#define FIFO_COLL_INTR_PF8K_SHIFT		(3)
+
+#define FIFO_COLL_INTR_EN_PF_COLL_INTR                ((uint32_t) (0x00000001))
+
+#define FIFO_COLL_INTR_EN_PF0_SHIFT		(0)
+#define FIFO_COLL_INTR_EN_PF1_SHIFT		(1)
+#define FIFO_COLL_INTR_EN_PF2_SHIFT		(2)
+#define FIFO_COLL_INTR_EN_PF8K_SHIFT	(3)
+
+/******************************************************************************
+ *                                   IO_MUX                                   *
+ ******************************************************************************/
+
+/* Common bit definition for all PAD control registers */
+
+#define PAD_CTRL_SEL_AO_REG			((uint32_t) (0x00000000))
+#define PAD_CTRL_SEL_OTHER			((uint32_t) (0x00000008))
+#define PAD_CTRL_SEL_FPGA			((uint32_t) (0x00000010))
+#define PAD_OEN_DISABLE                             ((uint32_t) (0x00000020))
+#define PAD_OEN_NORMAL                              ((uint32_t) (0x00000000))
+#define PAD_P_Z                                     ((uint32_t) (0x00000000))
+#define PAD_P_PULLUP                                ((uint32_t) (0x00000040))
+#define PAD_P_PULLDOWN                              ((uint32_t) (0x00000080))
+#define PAD_P_KEEPER                                ((uint32_t) (0x000000C0))
+#define PAD_E_2MA                                   ((uint32_t) (0x00000000))
+#define PAD_E_4MA                                   ((uint32_t) (0x00000100))
+#define PAD_E_8MA                                   ((uint32_t) (0x00000200))
+#define PAD_E_12MA                                  ((uint32_t) (0x00000300))
+#define PAD_SR_FAST                                 ((uint32_t) (0x00000400))
+#define PAD_SR_SLOW                                 ((uint32_t) (0x00000000))
+#define PAD_REN_ENABLE                              ((uint32_t) (0x00000800))
+#define PAD_REN_DISABLE                             ((uint32_t) (0x00000000))
+#define PAD_SMT_ENABLE                              ((uint32_t) (0x00001000))
+#define PAD_SMT_DISABLE                             ((uint32_t) (0x00000000))
+
+
+#define PAD_E_12MA                                  ((uint32_t) (0x00000300))
+#define PAD_OEN_NORMAL                              ((uint32_t) (0x00000000))
+
+#define SDA0_SEL_PAD1                               ((uint32_t) (0x00000001))
+#define SDA1_SEL_PAD10                              ((uint32_t) (0x00000001))
+#define SDA1_SEL_PAD32                              ((uint32_t) (0x00000002))
+#define SCL1_SEL_PAD33                              ((uint32_t) (0x00000002))
+#define SDA2_SEL_PAD34                              ((uint32_t) (0x00000001))
+#define SCL0_SEL_PAD0                               ((uint32_t) (0x00000000))
+#define SCL0_SEL_0                                  ((uint32_t) (0x00000001))
+#define SCL1_SEL_0                                  ((uint32_t) (0x00000000))
+#define SCL1_SEL_PAD9                               ((uint32_t) (0x00000001))
+#define SCL2_SEL_0                                  ((uint32_t) (0x00000000))
+#define SCL2_SEL_PAD33                              ((uint32_t) (0x00000001))
+
+#define SPIS_CLK_SEL_PAD17                          ((uint32_t) (0x00000000))
+#define SPIS_CLK_SEL_0                              ((uint32_t) (0x00000001))
+
+#define SPIS_SSN_SEL_PAD20                          ((uint32_t) (0x00000000))
+#define SPIS_SSN_SEL_0                              ((uint32_t) (0x00000001))
+
+#define SPIS_MOSI_SEL_PAD19                         ((uint32_t) (0x00000000))
+#define SPIS_MOSI_SEL_0                             ((uint32_t) (0x00000001))
+
+#define SPIS_MISO_SEL_PAD23                         ((uint32_t) (0x00000000))
+#define SPIS_MISO_SEL_0                             ((uint32_t) (0x00000001))
+
+#define PDM_DATA_SEL_0                              ((uint32_t) (0x00000000))
+#define PDM_DATA_SEL_PAD7                           ((uint32_t) (0x00000001))
+
+#define I2S_DATA_SEL_0                              ((uint32_t) (0x00000000))
+#define I2S_DATA_SEL_PAD7                           ((uint32_t) (0x00000001))
+
+#define UART_RXD_SEL_0                              ((uint32_t) (0x00000000))
+#define UART_RXD_SEL_PAD16                          ((uint32_t) (0x00000002))
+#define UART_RXD_SEL_PAD45                          ((uint32_t) (0x00000004))
+
+#define UART_TXD_SEL_0                              ((uint32_t) (0x00000000))
+#define UART_TXD_SEL_PAD44                          ((uint32_t) (0x00000003))
+
+#define IRDA_SIRIN_SEL_0                            ((uint32_t) (0x00000000))
+#define IRDA_SIRIN_SEL_PAD6                         ((uint32_t) (0x00000001))
+#define IRDA_SIRIN_SEL_PAD11                        ((uint32_t) (0x00000002))
+#define IRDA_SIRIN_SEL_PAD13                        ((uint32_t) (0x00000003))
+#define IRDA_SIRIN_SEL_PAD26                        ((uint32_t) (0x00000004))
+#define IRDA_SIRIN_SEL_PAD28                        ((uint32_t) (0x00000005))
+#define IRDA_SIRIN_SEL_PAD31                        ((uint32_t) (0x00000006))
+#define IRDA_SIRIN_SEL_PAD33                        ((uint32_t) (0x00000007))
+
+#define S_INTR_0_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_0_SEL_PAD2                           ((uint32_t) (0x00000001))
+
+#define S_INTR_1_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_1_SEL_PAD4                           ((uint32_t) (0x00000001))
+#define S_INTR_1_SEL_PAD11                          ((uint32_t) (0x00000002))
+#define S_INTR_1_SEL_PAD15                          ((uint32_t) (0x00000003))
+#define S_INTR_1_SEL_PAD26                          ((uint32_t) (0x00000004))
+#define S_INTR_1_SEL_PAD32                          ((uint32_t) (0x00000005))
+
+#define S_INTR_2_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_2_SEL_PAD5                           ((uint32_t) (0x00000001))
+#define S_INTR_2_SEL_PAD12                          ((uint32_t) (0x00000002))
+#define S_INTR_2_SEL_PAD16                          ((uint32_t) (0x00000003))
+#define S_INTR_2_SEL_PAD27                          ((uint32_t) (0x00000004))
+#define S_INTR_2_SEL_PAD33                          ((uint32_t) (0x00000005))
+
+#define S_INTR_3_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_3_SEL_PAD6                           ((uint32_t) (0x00000001))
+#define S_INTR_3_SEL_PAD13                          ((uint32_t) (0x00000002))
+#define S_INTR_3_SEL_PAD21                          ((uint32_t) (0x00000003))
+#define S_INTR_3_SEL_PAD28                          ((uint32_t) (0x00000004))
+#define S_INTR_3_SEL_PAD34                          ((uint32_t) (0x00000005))
+
+#define S_INTR_4_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_4_SEL_PAD7                           ((uint32_t) (0x00000001))
+#define S_INTR_4_SEL_PAD14                          ((uint32_t) (0x00000002))
+#define S_INTR_4_SEL_PAD22                          ((uint32_t) (0x00000003))
+#define S_INTR_4_SEL_PAD35                          ((uint32_t) (0x00000004))
+
+#define S_INTR_5_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_5_SEL_PAD8                           ((uint32_t) (0x00000001))
+#define S_INTR_5_SEL_PAD23                          ((uint32_t) (0x00000002))
+#define S_INTR_5_SEL_PAD29                          ((uint32_t) (0x00000003))
+
+#define S_INTR_6_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_6_SEL_PAD9                           ((uint32_t) (0x00000001))
+#define S_INTR_6_SEL_PAD24                          ((uint32_t) (0x00000002))
+#define S_INTR_6_SEL_PAD30                          ((uint32_t) (0x00000003))
+
+#define S_INTR_7_SEL_0                              ((uint32_t) (0x00000000))
+#define S_INTR_7_SEL_PAD10                          ((uint32_t) (0x00000001))
+#define S_INTR_7_SEL_PAD25                          ((uint32_t) (0x00000002))
+#define S_INTR_7_SEL_PAD31                          ((uint32_t) (0x00000003))
+
+#define NUARTCTS_SEL_0                              ((uint32_t) (0x00000000))
+#define NUARTCTS_SEL_PAD21                          ((uint32_t) (0x00000001))
+
+#define IO_REG_SEL_PAD7                             ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD11                            ((uint32_t) (0x00000001))
+#define IO_REG_SEL_PAD10                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD12                            ((uint32_t) (0x00000002))
+#define IO_REG_SEL_PAD15                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD13                            ((uint32_t) (0x00000004))
+#define IO_REG_SEL_PAD16                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD14                            ((uint32_t) (0x00000008))
+#define IO_REG_SEL_PAD22                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD29                            ((uint32_t) (0x00000010))
+#define IO_REG_SEL_PAD23                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD30                            ((uint32_t) (0x00000020))
+#define IO_REG_SEL_PAD25                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD31                            ((uint32_t) (0x00000040))
+#define IO_REG_SEL_PAD26                            ((uint32_t) (0x00000000))
+#define IO_REG_SEL_PAD32                            ((uint32_t) (0x00000080))
+
+#define SW_CLK_SEL_PAD8                             ((uint32_t) (0x00000000))
+#define SW_CLK_SEL_0                                ((uint32_t) (0x00000001))
+
+#define SW_IO_SEL_PAD8                              ((uint32_t) (0x00000000))
+#define SW_IO_SEL_0                                 ((uint32_t) (0x00000001))
+
+#define FBIO_SEL_0                                  ((uint32_t) (0x00000000))
+#define FBIO_SEL_PAD                                ((uint32_t) (0x00000001))
+
+#define FBIO_SEL_25_PAD17                           ((uint32_t) (0x00000000))
+#define FBIO_SEL_25_PAD34                           ((uint32_t) (0x00000001))
+#define FBIO_SEL_27_PAD18                           ((uint32_t) (0x00000000))
+#define FBIO_SEL_27_PAD26                           ((uint32_t) (0x00000002))
+#define FBIO_SEL_29_PAD19                           ((uint32_t) (0x00000000))
+#define FBIO_SEL_29_PAD27                           ((uint32_t) (0x00000004))
+#define FBIO_SEL_31_PAD20                           ((uint32_t) (0x00000000))
+#define FBIO_SEL_31_PAD35                           ((uint32_t) (0x00000008))
+
+/******************************************************************************
+ *                               INTR_CTRL                                    *
+ ******************************************************************************/
+#define GPIO_7_INTR                                 ((uint32_t) (0x00000080))
+#define GPIO_6_INTR                                 ((uint32_t) (0x00000040))
+#define GPIO_5_INTR                                 ((uint32_t) (0x00000020))
+#define GPIO_4_INTR                                 ((uint32_t) (0x00000010))
+#define GPIO_3_INTR                                 ((uint32_t) (0x00000008))
+#define GPIO_2_INTR                                 ((uint32_t) (0x00000004))
+#define GPIO_1_INTR                                 ((uint32_t) (0x00000002))
+#define GPIO_0_INTR                                 ((uint32_t) (0x00000001))
+
+#define GPIO_7_INTR_RAW                             ((uint32_t) (0x00000080))
+#define GPIO_6_INTR_RAW                             ((uint32_t) (0x00000040))
+#define GPIO_5_INTR_RAW                             ((uint32_t) (0x00000020))
+#define GPIO_4_INTR_RAW                             ((uint32_t) (0x00000010))
+#define GPIO_3_INTR_RAW                             ((uint32_t) (0x00000008))
+#define GPIO_2_INTR_RAW                             ((uint32_t) (0x00000004))
+#define GPIO_1_INTR_RAW                             ((uint32_t) (0x00000002))
+#define GPIO_0_INTR_RAW                             ((uint32_t) (0x00000001))
+
+#define GPIO_7_INTR_TYPE_EDGE                       ((uint32_t) (0x00000080))
+#define GPIO_7_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_6_INTR_TYPE_EDGE                       ((uint32_t) (0x00000040))
+#define GPIO_6_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_5_INTR_TYPE_EDGE                       ((uint32_t) (0x00000020))
+#define GPIO_5_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_4_INTR_TYPE_EDGE                       ((uint32_t) (0x00000010))
+#define GPIO_4_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_3_INTR_TYPE_EDGE                       ((uint32_t) (0x00000008))
+#define GPIO_3_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_2_INTR_TYPE_EDGE                       ((uint32_t) (0x00000004))
+#define GPIO_2_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_1_INTR_TYPE_EDGE                       ((uint32_t) (0x00000002))
+#define GPIO_1_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+#define GPIO_0_INTR_TYPE_EDGE                       ((uint32_t) (0x00000001))
+#define GPIO_0_INTR_TYPE_LEVEL                      ((uint32_t) (0x00000000))
+
+#define GPIO_7_INTR_POL_HI_RISE                     ((uint32_t) (0x00000080))
+#define GPIO_7_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_6_INTR_POL_HI_RISE                     ((uint32_t) (0x00000040))
+#define GPIO_6_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_5_INTR_POL_HI_RISE                     ((uint32_t) (0x00000020))
+#define GPIO_5_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_4_INTR_POL_HI_RISE                     ((uint32_t) (0x00000010))
+#define GPIO_4_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_3_INTR_POL_HI_RISE                     ((uint32_t) (0x00000008))
+#define GPIO_3_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_2_INTR_POL_HI_RISE                     ((uint32_t) (0x00000004))
+#define GPIO_2_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_1_INTR_POL_HI_RISE                     ((uint32_t) (0x00000002))
+#define GPIO_1_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+#define GPIO_0_INTR_POL_HI_RISE                     ((uint32_t) (0x00000001))
+#define GPIO_0_INTR_POL_LO_FALL                     ((uint32_t) (0x00000000))
+
+#define GPIO_7_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000080))
+#define GPIO_6_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000040))
+#define GPIO_5_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000020))
+#define GPIO_4_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000010))
+#define GPIO_3_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000008))
+#define GPIO_2_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000004))
+#define GPIO_1_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000002))
+#define GPIO_0_INTR_EN_AP_ENABLE                    ((uint32_t) (0x00000001))
+
+#define GPIO_7_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000080))
+#define GPIO_6_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000040))
+#define GPIO_5_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000020))
+#define GPIO_4_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000010))
+#define GPIO_3_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000008))
+#define GPIO_2_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000004))
+#define GPIO_1_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000002))
+#define GPIO_0_INTR_EN_M4_ENABLE                    ((uint32_t) (0x00000001))
+
+#define GPIO_7_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000080))
+#define GPIO_6_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000040))
+#define GPIO_5_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000020))
+#define GPIO_4_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000010))
+#define GPIO_3_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000008))
+#define GPIO_2_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000004))
+#define GPIO_1_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000002))
+#define GPIO_0_INTR_EN_FFE0_ENABLE                  ((uint32_t) (0x00000001))
+
+#define GPIO_7_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000080))
+#define GPIO_6_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000040))
+#define GPIO_5_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000020))
+#define GPIO_4_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000010))
+#define GPIO_3_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000008))
+#define GPIO_2_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000004))
+#define GPIO_1_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000002))
+#define GPIO_0_INTR_EN_FFE1_ENABLE                  ((uint32_t) (0x00000001))
+
+// naveen - s3b
+#define DMIC_VOICE_DET								((uint32_t)1<<23)
+#define LPSD_VOICE_DET								((uint32_t)1<<22)
+#define APBOOT_EN_DETECT							((uint32_t) (0x00040000))
+#define WDT_FFE_DETECT			   				    ((uint32_t) (0x00020000))
+#define FFE0_INTR_OTHERS_DETECT			   		    ((uint32_t) (0x00010000))
+#define RST_INTR_DETECT                             ((uint32_t) (0x00008000))
+#define RTC_INTR_DETECT                             ((uint32_t) (0x00004000))
+#define ADC_INTR_DETECT                             ((uint32_t) (0x00002000))
+#define PMU_TMR_INTR_DETECT                         ((uint32_t) (0x00001000))
+#define CFG_DMA_DONE_DETECT                         ((uint32_t) (0x00000800))
+#define SPI_MS_INTR_DETECT                          ((uint32_t) (0x00000400))
+#define AUD_INTR_DETECT                             ((uint32_t) (0x00000200))
+#define I2S_INTR_DETECT                             ((uint32_t) (0x00000100))
+
+#define PKFB_INTR_DETECT                            ((uint32_t) (0x00000080))
+#define FPU_INTR_DETECT                             ((uint32_t) (0x00000040))
+#define TIMEOUT_INTR_DETECT                         ((uint32_t) (0x00000020))
+#define WDOG_RST_DETECT                             ((uint32_t) (0x00000010))
+#define WDOG_INTR_DETECT                            ((uint32_t) (0x00000008))
+#define TIMER_INTR_DETECT                           ((uint32_t) (0x00000004))
+#define UART_INTR_DETECT                            ((uint32_t) (0x00000002))
+#define M4_SRAM_INTR_DETECT                         ((uint32_t) (0x00000001))
+
+#define DMIC_VOICE_INTR                             ((uint32_t) (0x00800000))
+#define LPSD_VOICE_INTR                             ((uint32_t) (0x00400000))
+#define SRAM_128KB_INTR                             ((uint32_t) (0x00200000))
+#define LDO50_PG_INTR                               ((uint32_t) (0x00100000))
+#define LDO30_PG_INTR                               ((uint32_t) (0x00080000))
+
+#define APBOOT_EN_DETECT	((uint32_t) (0x00040000))
+#define WDT_FFE_DETECT		((uint32_t) (0x00020000))
+#define FFE0_INTR_OTHERS_DETECT	((uint32_t) (0x00010000))
+
+#define DMIC_VOICE_EN_AP        ((uint32_t) (0x00800000))
+#define LPSD_VOICE_EN_AP        ((uint32_t) (0x00400000))
+#define SRAM_128KB_EN_AP        ((uint32_t) (0x00200000))
+#define LDO50_PG_EN_AP          ((uint32_t) (0x00100000))
+#define LDO30_PG_EN_AP          ((uint32_t) (0x00080000))
+#define APBOOT_EN_AP   		((uint32_t) (0x00040000))
+#define WDT_FFE_EN_AP 		((uint32_t) (0x00020000))
+#define FFE0_INTR_OTHERS_EN_AP 	((uint32_t) (0x00010000))
+#define RST_INTR_EN_AP          ((uint32_t) (0x00008000))
+#define RTC_INTR_EN_AP          ((uint32_t) (0x00004000))
+#define ADC_INTR_EN_AP          ((uint32_t) (0x00002000))
+#define PMU_TMR_INTR_EN_AP      ((uint32_t) (0x00001000))
+#define CFG_DMA_DONE_EN_AP      ((uint32_t) (0x00000800))
+#define SPI_MS_INTR_EN_AP       ((uint32_t) (0x00000400))
+#define PKFB_INTR_EN_AP         ((uint32_t) (0x00000080))
+#define FPU_INTR_EN_AP          ((uint32_t) (0x00000040))
+#define TIMEOUT_INTR_EN_AP      ((uint32_t) (0x00000020))
+#define WDOG_RST_EN_AP          ((uint32_t) (0x00000010))
+#define WDOG_INTR_EN_AP         ((uint32_t) (0x00000008))
+#define TIMER_INTR_EN_AP        ((uint32_t) (0x00000004))
+#define UART_INTR_EN_AP         ((uint32_t) (0x00000002))
+#define M4_SRAM_INTR_EN_AP      ((uint32_t) (0x00000001))
+
+#define DMIC_VOICE_EN_M4        ((uint32_t) (0x00800000))
+#define LPSD_VOICE_EN_M4        ((uint32_t) (0x00400000))
+#define SRAM_128KB_EN_M4        ((uint32_t) (0x00200000))
+#define LDO50_PG_EN_M4          ((uint32_t) (0x00100000))
+#define LDO30_PG_EN_M4          ((uint32_t) (0x00080000))
+#define APBOOT_EN_M4   		((uint32_t) (0x00040000))
+#define WDT_FFE_EN_M4 		((uint32_t) (0x00020000))
+#define FFE0_INTR_OTHERS_EN_M4 	((uint32_t) (0x00010000))
+#define RST_INTR_EN_M4          ((uint32_t) (0x00008000))
+#define RTC_INTR_EN_M4          ((uint32_t) (0x00004000))
+#define ADC_INTR_EN_M4          ((uint32_t) (0x00002000))
+#define PMU_TMR_INTR_EN_M4      ((uint32_t) (0x00001000))
+#define CFG_DMA_DONE_EN_M4      ((uint32_t) (0x00000800))
+#define SPI_MS_INTR_EN_M4       ((uint32_t) (0x00000400))
+#define PKFB_INTR_EN_M4         ((uint32_t) (0x00000080))
+#define FPU_INTR_EN_M4          ((uint32_t) (0x00000040))
+#define TIMEOUT_INTR_EN_M4      ((uint32_t) (0x00000020))
+#define WDOG_RST_EN_M4          ((uint32_t) (0x00000010))
+#define WDOG_INTR_EN_M4         ((uint32_t) (0x00000008))
+#define TIMER_INTR_EN_M4        ((uint32_t) (0x00000004))
+#define UART_INTR_EN_M4         ((uint32_t) (0x00000002))
+#define M4_SRAM_INTR_EN_M4      ((uint32_t) (0x00000001))
+
+#define SW_INTR_1               ((uint32_t) (0x00000001))
+#define SW_INTR_1_EN_AP         ((uint32_t) (0x00000001))
+#define SW_INTR_1_EN_M4         ((uint32_t) (0x00000001))
+#define SW_INTR_2               ((uint32_t) (0x00000001))
+#define SW_INTR_2_EN_AP         ((uint32_t) (0x00000001))
+#define SW_INTR_2_EN_M4         ((uint32_t) (0x00000001))
+
+#define FFE0_7_INTR_DETECT	((uint32_t)0x00000080)
+#define FFE0_6_INTR_DETECT	((uint32_t) (0x00000040))
+#define FFE0_5_INTR_DETECT	((uint32_t) (0x00000020))
+#define FFE0_4_INTR_DETECT	((uint32_t) (0x00000010))
+#define FFE0_3_INTR_DETECT	((uint32_t) (0x00000008))
+#define FFE0_2_INTR_DETECT	((uint32_t) (0x00000004))
+#define FFE0_1_INTR_DETECT	((uint32_t) (0x00000002))
+#define FFE0_0_INTR_DETECT	((uint32_t) (0x00000001))
+
+#define FFE0_7_INTR_EN_AP 	((uint32_t) (0x00000080))
+#define FFE0_6_INTR_EN_AP 	((uint32_t) (0x00000040))
+#define FFE0_5_INTR_EN_AP 	((uint32_t) (0x00000020))
+#define FFE0_4_INTR_EN_AP 	((uint32_t) (0x00000010))
+#define FFE0_3_INTR_EN_AP 	((uint32_t) (0x00000008))
+#define FFE0_2_INTR_EN_AP 	((uint32_t) (0x00000004))
+#define FFE0_1_INTR_EN_AP 	((uint32_t) (0x00000002))
+#define FFE0_0_INTR_EN_AP 	((uint32_t) (0x00000001))
+
+#define FFE0_7_INTR_EN_M4 	((uint32_t) (0x00000080))
+#define FFE0_6_INTR_EN_M4 	((uint32_t) (0x00000040))
+#define FFE0_5_INTR_EN_M4 	((uint32_t) (0x00000020))
+#define FFE0_4_INTR_EN_M4  	((uint32_t) (0x00000010))
+#define FFE0_3_INTR_EN_M4  	((uint32_t) (0x00000008))
+#define FFE0_2_INTR_EN_M4  	((uint32_t) (0x00000004))
+#define FFE0_1_INTR_EN_M4  	((uint32_t) (0x00000002))
+#define FFE0_0_INTR_EN_M4  	((uint32_t) (0x00000001))
+
+#define FFE1_7_INTR_DETECT	((uint32_t) (0x00000080))
+#define FFE1_6_INTR_DETECT	((uint32_t) (0x00000040))
+#define FFE1_5_INTR_DETECT	((uint32_t) (0x00000020))
+#define FFE1_4_INTR_DETECT	((uint32_t) (0x00000010))
+#define FFE1_3_INTR_DETECT	((uint32_t) (0x00000008))
+#define FFE1_2_INTR_DETECT	((uint32_t) (0x00000004))
+#define FFE1_1_INTR_DETECT	((uint32_t) (0x00000002))
+#define FFE1_0_INTR_DETECT	((uint32_t) (0x00000001))
+
+#define FFE1_7_INTR_EN_AP 	((uint32_t) (0x00000080))
+#define FFE1_6_INTR_EN_AP 	((uint32_t) (0x00000040))
+#define FFE1_5_INTR_EN_AP 	((uint32_t) (0x00000020))
+#define FFE1_4_INTR_EN_AP 	((uint32_t) (0x00000010))
+#define FFE1_3_INTR_EN_AP 	((uint32_t) (0x00000008))
+#define FFE1_2_INTR_EN_AP 	((uint32_t) (0x00000004))
+#define FFE1_1_INTR_EN_AP 	((uint32_t) (0x00000002))
+#define FFE1_0_INTR_EN_AP 	((uint32_t) (0x00000001))
+
+#define FFE1_7_INTR_EN_M4 	((uint32_t) (0x00000080))
+#define FFE1_6_INTR_EN_M4 	((uint32_t) (0x00000040))
+#define FFE1_5_INTR_EN_M4 	((uint32_t) (0x00000020))
+#define FFE1_4_INTR_EN_M4  	((uint32_t) (0x00000010))
+#define FFE1_3_INTR_EN_M4  	((uint32_t) (0x00000008))
+#define FFE1_2_INTR_EN_M4  	((uint32_t) (0x00000004))
+#define FFE1_1_INTR_EN_M4  	((uint32_t) (0x00000002))
+#define FFE1_0_INTR_EN_M4  	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_DETECT	((uint32_t) (0x00000008))
+#define FB_2_INTR_DETECT	((uint32_t) (0x00000004))
+#define FB_1_INTR_DETECT	((uint32_t) (0x00000002))
+#define FB_0_INTR_DETECT	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_RAW   	((uint32_t) (0x00000008))
+#define FB_2_INTR_RAW   	((uint32_t) (0x00000004))
+#define FB_1_INTR_RAW   	((uint32_t) (0x00000002))
+#define FB_0_INTR_RAW   	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_TYPE_LEVEL 	((uint32_t) (0x00000000))
+#define FB_3_INTR_TYPE_EDGE 	((uint32_t) (0x00000008))
+#define FB_2_INTR_TYPE_LEVEL    ((uint32_t) (0x00000000))
+#define FB_2_INTR_TYPE_EDGE     ((uint32_t) (0x00000004))
+#define FB_1_INTR_TYPE_LEVEL	((uint32_t) (0x00000000))
+#define FB_1_INTR_TYPE_EDGE	((uint32_t) (0x00000002))
+#define FB_0_INTR_TYPE_LEVEL	((uint32_t) (0x00000000))
+#define FB_0_INTR_TYPE_EDGE	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_POL_LO_FALL 	((uint32_t) (0x00000000))
+#define FB_3_INTR_POL_HI_RISE 	((uint32_t) (0x00000008))
+#define FB_2_INTR_POL_LO_FALL 	((uint32_t) (0x00000000))
+#define FB_2_INTR_POL_HI_RISE 	((uint32_t) (0x00000004))
+#define FB_1_INTR_POL_LO_FALL 	((uint32_t) (0x00000000))
+#define FB_1_INTR_POL_HI_RISE 	((uint32_t) (0x00000002))
+#define FB_0_INTR_POL_LO_FALL 	((uint32_t) (0x00000000))
+#define FB_0_INTR_POL_HI_RISE 	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_EN_AP 	((uint32_t) (0x00000008))
+#define FB_2_INTR_EN_AP 	((uint32_t) (0x00000004))
+#define FB_1_INTR_EN_AP 	((uint32_t) (0x00000002))
+#define FB_0_INTR_EN_AP 	((uint32_t) (0x00000001))
+
+#define FB_3_INTR_EN_M4 	((uint32_t) (0x00000008))
+#define FB_2_INTR_EN_M4 	((uint32_t) (0x00000004))
+#define FB_1_INTR_EN_M4 	((uint32_t) (0x00000002))
+#define FB_0_INTR_EN_M4 	((uint32_t) (0x00000001))
+
+/******************************************************************************
+ *                                 SPI_MS                                     *
+ ******************************************************************************/
+
+#define CTRLR0_DFS_32_4_BIT                         ((uint32_t) (0x00030000))
+#define CTRLR0_DFS_32_5_BIT                         ((uint32_t) (0x00040000))
+#define CTRLR0_DFS_32_6_BIT                         ((uint32_t) (0x00050000))
+#define CTRLR0_DFS_32_7_BIT                         ((uint32_t) (0x00060000))
+#define CTRLR0_DFS_32_8_BIT                         ((uint32_t) (0x00070000))
+#define CTRLR0_DFS_32_9_BIT                         ((uint32_t) (0x00080000))
+#define CTRLR0_DFS_32_10_BIT                        ((uint32_t) (0x00090000))
+#define CTRLR0_DFS_32_11_BIT                        ((uint32_t) (0x000A0000))
+#define CTRLR0_DFS_32_12_BIT                        ((uint32_t) (0x000B0000))
+#define CTRLR0_DFS_32_13_BIT                        ((uint32_t) (0x000C0000))
+#define CTRLR0_DFS_32_14_BIT                        ((uint32_t) (0x000D0000))
+#define CTRLR0_DFS_32_15_BIT                        ((uint32_t) (0x000E0000))
+#define CTRLR0_DFS_32_16_BIT                        ((uint32_t) (0x000F0000))
+#define CTRLR0_CFS_1_BIT                            ((uint32_t) (0x00000000))
+#define CTRLR0_CFS_2_BIT                            ((uint32_t) (0x00001000))
+#define CTRLR0_CFS_3_BIT                            ((uint32_t) (0x00002000))
+#define CTRLR0_CFS_4_BIT                            ((uint32_t) (0x00003000))
+#define CTRLR0_CFS_5_BIT                            ((uint32_t) (0x00004000))
+#define CTRLR0_CFS_6_BIT                            ((uint32_t) (0x00005000))
+#define CTRLR0_CFS_7_BIT                            ((uint32_t) (0x00006000))
+#define CTRLR0_CFS_8_BIT                            ((uint32_t) (0x00007000))
+#define CTRLR0_CFS_9_BIT                            ((uint32_t) (0x00008000))
+#define CTRLR0_CFS_10_BIT                           ((uint32_t) (0x00009000))
+#define CTRLR0_CFS_11_BIT                           ((uint32_t) (0x0000A000))
+#define CTRLR0_CFS_12_BIT                           ((uint32_t) (0x0000B000))
+#define CTRLR0_CFS_13_BIT                           ((uint32_t) (0x0000C000))
+#define CTRLR0_CFS_14_BIT                           ((uint32_t) (0x0000D000))
+#define CTRLR0_CFS_15_BIT                           ((uint32_t) (0x0000E000))
+#define CTRLR0_CFS_16_BIT                           ((uint32_t) (0x0000F000))
+#define CTRLR0_SRL_TEST_MODE                        ((uint32_t) (0x00000800))
+#define CTRLR0_SRL_NORMAL_MODE                      ((uint32_t) (0x00000000))
+#define CTRLR0_SLV_OE                               ((uint32_t) (0x00000400))
+#define CTRLR0_TMOD_TX_RX                           ((uint32_t) (0x00000000))
+#define CTRLR0_TMOD_TX                              ((uint32_t) (0x00000100))
+#define CTRLR0_TMOD_RX                              ((uint32_t) (0x00000200))
+#define CTRLR0_TMOD_EEPROM                          ((uint32_t) (0x00000300))
+#define CTRLR0_SCPOL_LO                             ((uint32_t) (0x00000000))
+#define CTRLR0_SCPOL_HI                             ((uint32_t) (0x00000080))
+#define CTRLR0_SCPH_MID                             ((uint32_t) (0x00000000))
+#define CTRLR0_SCPH_START                           ((uint32_t) (0x00000040))
+#define CTRLR0_DFS_4_BIT                            ((uint32_t) (0x00000003))
+#define CTRLR0_DFS_5_BIT                            ((uint32_t) (0x00000004))
+#define CTRLR0_DFS_6_BIT                            ((uint32_t) (0x00000005))
+#define CTRLR0_DFS_7_BIT                            ((uint32_t) (0x00000006))
+#define CTRLR0_DFS_8_BIT                            ((uint32_t) (0x00000007))
+#define CTRLR0_DFS_9_BIT                            ((uint32_t) (0x00000008))
+#define CTRLR0_DFS_10_BIT                           ((uint32_t) (0x00000009))
+#define CTRLR0_DFS_11_BIT                           ((uint32_t) (0x0000000A))
+#define CTRLR0_DFS_12_BIT                           ((uint32_t) (0x0000000B))
+#define CTRLR0_DFS_13_BIT                           ((uint32_t) (0x0000000C))
+#define CTRLR0_DFS_14_BIT                           ((uint32_t) (0x0000000D))
+#define CTRLR0_DFS_15_BIT                           ((uint32_t) (0x0000000E))
+#define CTRLR0_DFS_16_BIT                           ((uint32_t) (0x0000000F))
+
+#define SSIENR_SSI_DISABLE                          ((uint32_t) (0x00000000))
+#define SSIENR_SSI_EN                               ((uint32_t) (0x00000001))
+
+#define SER_SS_0_N_SELECTED                         ((uint32_t) (0x00000001))
+#define SER_SS_1_N_SELECTED                         ((uint32_t) (0x00000002))
+#define SER_SS_2_N_SELECTED                         ((uint32_t) (0x00000004))
+
+#define SR_DCOL_TX_DATA_ERR                         ((uint32_t) (0x00000040))
+#define SR_RFF                                      ((uint32_t) (0x00000010))
+#define SR_RFNE                                     ((uint32_t) (0x00000008))
+#define SR_TFE                                      ((uint32_t) (0x00000004))
+#define SR_TFNF                                     ((uint32_t) (0x00000002))
+#define SR_BUSY                                     ((uint32_t) (0x00000001))
+
+#define IMR_MSTIM_UNMASK                            ((uint32_t) (0x00000020))
+#define IMR_RXFIM_UNMASK                            ((uint32_t) (0x00000010))
+#define IMR_RXFOIM_UNMASK                           ((uint32_t) (0x00000008))
+#define IMR_RXUIM_UNMASK                            ((uint32_t) (0x00000004))
+#define IMR_TXOIM_UNMASK                            ((uint32_t) (0x00000002))
+#define IMR_TXEIM_UNMASK                            ((uint32_t) (0x00000001))
+
+#define ISR_MSTIM_ACTIVE                            ((uint32_t) (0x00000020))
+#define ISR_RXFIM_ACTIVE                            ((uint32_t) (0x00000010))
+#define ISR_RXFOIM_ACTIVE                           ((uint32_t) (0x00000008))
+#define ISR_RXUIM_ACTIVE                            ((uint32_t) (0x00000004))
+#define ISR_TXOIM_ACTIVE                            ((uint32_t) (0x00000002))
+#define ISR_TXEIM_ACTIVE                            ((uint32_t) (0x00000001))
+
+#define RISR_MSTIM_ACTIVE                           ((uint32_t) (0x00000020))
+#define RISR_RXFIM_ACTIVE                           ((uint32_t) (0x00000010))
+#define RISR_RXFOIM_ACTIVE                          ((uint32_t) (0x00000008))
+#define RISR_RXUIM_ACTIVE                           ((uint32_t) (0x00000004))
+#define RISR_TXOIM_ACTIVE                           ((uint32_t) (0x00000002))
+#define RISR_TXEIM_ACTIVE                           ((uint32_t) (0x00000002))
+
+/******************************************************************************
+ *                                   I2S                                      *
+ ******************************************************************************/
+#define IER_IEN                                     ((uint32_t) (0x00000001))
+
+#define IRER_RXEN                                   ((uint32_t) (0x00000001))
+
+#define CER_CLKEN                                   ((uint32_t) (0x00000001))
+
+#define CCR_WSS_16_CYCLES                           ((uint32_t) (0x00000000))
+#define CCR_WSS_24_CYCLES                           ((uint32_t) (0x00000008))
+#define CCR_WSS_32_CYCLES                           ((uint32_t) (0x00000010))
+#define CCR_SCLKG_NO_GATING                         ((uint32_t) (0x00000000))
+#define CCR_SCLKG_12_GATING                         ((uint32_t) (0x00000001))
+#define CCR_SCLKG_16_GATING                         ((uint32_t) (0x00000002))
+#define CCR_SCLKG_20_GATING                         ((uint32_t) (0x00000003))
+#define CCR_SCLKG_24_GATING                         ((uint32_t) (0x00000004))
+
+#define RXFFR_RESET                                 ((uint32_t) (0x00000001))
+
+#define RER0_RX_CHEN0_ENABLE                        ((uint32_t) (0x00000001))
+#define RER0_RX_CHEN0_DISABLE                       ((uint32_t) (0x00000000))
+
+#define RCR0_WLEN_IGNORE                            ((uint32_t) (0x00000000))
+#define RCR0_WLEN_12BIT                             ((uint32_t) (0x00000001))
+#define RCR0_WLEN_16BIT                             ((uint32_t) (0x00000002))
+
+#define ISR0_RXFO_VALID                             ((uint32_t) (0x00000002))
+#define ISR0_RXDA_VALID                             ((uint32_t) (0x00000001))
+
+#define IMR0_RXFOM                                  ((uint32_t) (0x00000002))
+#define IMR0_RXDAM                                  ((uint32_t) (0x00000001))
+
+#define RFCR0_RXCHDT_1BIT                           ((uint32_t) (0x00000000))
+#define RFCR0_RXCHDT_2BIT                           ((uint32_t) (0x00000001))
+#define RFCR0_RXCHDT_3BIT                           ((uint32_t) (0x00000002))
+#define RFCR0_RXCHDT_4BIT                           ((uint32_t) (0x00000003))
+#define RFCR0_RXCHDT_5BIT                           ((uint32_t) (0x00000004))
+#define RFCR0_RXCHDT_6BIT                           ((uint32_t) (0x00000005))
+#define RFCR0_RXCHDT_7BIT                           ((uint32_t) (0x00000006))
+#define RFCR0_RXCHDT_8BIT                           ((uint32_t) (0x00000007))
+
+#define RFF0_RXCHFR_RESET                           ((uint32_t) (0x00000001))
+
+#define AUD_P_CTRL_DMA_MUX_SEL                      ((uint32_t) (0x00000001))
+#define AUD_P_CTRL_MONO_SEL_MONO                    ((uint32_t) (0x00000002))
+#define AUD_P_CTRL_MONO_SEL_STEREO                  ((uint32_t) (0x00000000))
+#define AUD_P_CTRL_RIGHT_SEL_RIGHT                  ((uint32_t) (0x00000004))
+#define AUD_P_CTRL_RIGHT_SEL_LEFT                   ((uint32_t) (0x00000000))
+#define AUD_P_CTRL_I2S_SEL_I2S                      ((uint32_t) (0x00000008))
+#define AUD_P_CTRL_I2S_SEL_PDM                      ((uint32_t) (0x00000000))
+
+#define AUD_P_INTR_FIFO_OVERFLOW                    ((uint32_t) (0x00000001))
+#define AUD_P_INTR_RX_OVERRUN                       ((uint32_t) (0x00000002))
+#define AUD_P_INTR_RX_DATA_AVALIABLE                ((uint32_t) (0x00000004))
+
+#define AUD_P_INTR_MASK_FIFO_OVERFLOW_MASK          ((uint32_t) (0x00000001))
+#define AUD_P_INTR_MASK_RX_OVERRUN_MASK             ((uint32_t) (0x00000002))
+#define AUD_P_INTR_MASK_RX_DATA_AVALIABLE_MASK      ((uint32_t) (0x00000004))
+
+/******************************************************************************
+ *                                   AUD                                      *
+ ******************************************************************************/
+#define AUD_H_CTRL_DMA_START                        ((uint32_t) (0x00000001))
+#define AUD_H_CTRL_DMA_STOP                         ((uint32_t) (0x00000002))
+#define AUD_H_CTRL_LS_ENABLE                        ((uint32_t) (0x00000004))
+#define AUD_H_CTRL_POWER_REQ_DISABLE                ((uint32_t) (0x00000008))
+#define AUD_H_CTRL_AHB_ADDR_CYC                     ((uint32_t) (0x00000010))
+#define AUD_H_CTRL_AHB_ADDR_XFR                     ((uint32_t) (0x00000020))
+#define AUD_H_CTRL_AHB_DATA_CYC                     ((uint32_t) (0x00000040))
+#define AUD_H_CTRL_AHB_DATA_XFR                     ((uint32_t) (0x00000080))
+
+#define IDLE_CYC_PERIOD_MASK                        ((uint32_t) (0x0000001F))
+#define AHB_IDLE_PERIOD_MASK                        ((uint32_t) (0x0000001F))
+#define DMA_BLOCK_SIZE_MASK                         ((uint32_t) (0x0003FFFC))
+#define DMA_WRAP_SIZE_MASK                          ((uint32_t) (0x0003FFFC))
+#define DMA_XFER_CNT_MASK                           ((uint32_t) (0x0003FFFC))
+#define DMA_START_ADDR_MASK                         ((uint32_t) (0xFFFFFFFC))
+#define DMA_DEST_ADDR_MASK                          ((uint32_t) (0xFFFFFFFC))
+#define FIFO_SYNC_THRESHOLD_LVL_MASK                ((uint32_t) (0x00003FFC))
+
+#define AHB_FIFO_SYNC_TEST_RM_MASK                  ((uint32_t) (0x00000003))
+#define AHB_FIFO_SYNC_TEST_RM_RSV_MASK              ((uint32_t) (0x0000000C))
+#define AHB_FIFO_SYNC_TEST_RME_MASK                 ((uint32_t) (0x00000010))
+#define AHB_FIFO_SYNC_TEST_1_MASK                   ((uint32_t) (0x00000020))
+
+#define AHB_H_INTR_AUD_POWER_ON_REQ                 ((uint32_t) (0x00000001))
+#define AHB_H_INTR_AUD_POWER_OFF_REQ                ((uint32_t) (0x00000002))
+#define AHB_H_INTR_AUD_BLOCK                        ((uint32_t) (0x00000004))
+#define AHB_H_INTR_AUD_WRAP                         ((uint32_t) (0x00000008))
+#define AHB_H_INTR_FIFO_SYNC_UNDERFLOW              ((uint32_t) (0x00000010))
+#define AHB_H_INTR_FIFO_SYNC_OVERFLOW               ((uint32_t) (0x00000020))
+#define AHB_H_INTR_FIFO_ASYNC_UNDERFLOW             ((uint32_t) (0x00000040))
+#define AHB_H_INTR_DEEP_SLEEP_ERROR                 ((uint32_t) (0x00000080))
+#define AHB_H_INTR_HERROR                           ((uint32_t) (0x00000100))
+
+#define AHB_H_INTR_MASK_AUD_POWER_ON_REQ            ((uint32_t) (0x00000001))
+#define AHB_H_INTR_MASK_AUD_POWER_OFF_REQ           ((uint32_t) (0x00000002))
+#define AHB_H_INTR_MASK_AUD_BLOCK                   ((uint32_t) (0x00000004))
+#define AHB_H_INTR_MASK_AUD_WRAP                    ((uint32_t) (0x00000008))
+#define AHB_H_INTR_MASK_FIFO_SYNC_UNDERFLOW         ((uint32_t) (0x00000010))
+#define AHB_H_INTR_MASK_FIFO_SYNC_OVERFLOW          ((uint32_t) (0x00000020))
+#define AHB_H_INTR_MASK_FIFO_ASYNC_UNDERFLOW        ((uint32_t) (0x00000040))
+#define AHB_H_INTR_MASK_DEEP_SLEEP_ERROR            ((uint32_t) (0x00000080))
+#define AHB_H_INTR_MASK_HERROR                      ((uint32_t) (0x00000100))
+
+#define DMA_WRAP_SIZE_MASK_MASK                     ((uint32_t) (0x0003FFFC))
+#define DS_WAKEUP_DLY_MASK                          ((uint32_t) (0x0000000F))
+
+
+/******************************************************************************
+ *                                   PMU                                      *
+ ******************************************************************************/
+#define PMU_WIC_CONTROL_ENABLE                      ((uint32_t) (0x00000001))
+
+#define PMU_MISC_SW_WU_A1_WU                        ((uint32_t) (0x00000040))
+#define PMU_MISC_SW_WU_I2S_WU                       ((uint32_t) (0x00000020))
+#define PMU_MISC_SW_WU_RES_WU                       ((uint32_t) (0x00000010))
+#define PMU_MISC_SW_WU_DBG_WU                       ((uint32_t) (0x00000008))
+#define PMU_MISC_SW_WU_EFUSE_WU                     ((uint32_t) (0x00000004))
+#define PMU_MISC_SW_WU_TM_WU                        ((uint32_t) (0x00000002))
+#define PMU_MISC_SW_WU_SDMA_WU                      ((uint32_t) (0x00000001))
+
+#define PMU_FFE_PD_SRC_MASK_N						((uint32_t) (0x00000001))
+#define PMU_FFE_WU_SRC_MASK_N						((uint32_t) (0x00000001))
+
+#define PMU_FB_PD_SRC_MASK_N						((uint32_t) (0x00000001))
+#define PMU_FB_WU_SRC_SEN_GPIO0_INT					((uint32_t) (0x00000001))
+#define PMU_FB_WU_SRC_SEN_GPIO1_INT					((uint32_t) (0x00000002))
+#define PMU_FB_WU_SRC_SEN_GPIO2_INT					((uint32_t) (0x00000004))
+#define PMU_FB_WU_SRC_SEN_GPIO3_INT					((uint32_t) (0x00000008))
+#define PMU_FB_WU_SRC_SEN_GPIO4_INT					((uint32_t) (0x00000010))
+#define PMU_FB_WU_SRC_SEN_GPIO5_INT					((uint32_t) (0x00000020))
+#define PMU_FB_WU_SRC_SEN_GPIO6_INT					((uint32_t) (0x00000040))
+#define PMU_FB_WU_SRC_SEN_GPIO7_INT					((uint32_t) (0x00000080))
+#define PMU_FB_WU_SRC_FFE_TIMER						((uint32_t) (0x00000100))
+
+#define PMU_FFE_FB_PF_SW_WU_PF_WU                   ((uint32_t) (0x00000004))
+#define PMU_FFE_FB_PF_SW_WU_FB_WU                   ((uint32_t) (0x00000002))
+#define PMU_FFE_FB_PF_SW_WU_FFE_WU                  ((uint32_t) (0x00000001))
+
+#define PMU_M4S0_EVENT_PD                  	    	((uint32_t) (0x00000001))
+#define PMU_M4S0_EVENT_WU                  	    	((uint32_t) (0x00000001))
+
+#define PMU_M4S0_SW_PD                  			((uint32_t) (0x00000001))
+#define PMU_M4S1_SW_PD                  			((uint32_t) (0x00000002))
+#define PMU_M4S2_SW_PD                  		((uint32_t) (0x00000004))
+#define PMU_M4S3_SW_PD                  		((uint32_t) (0x00000008))
+#define PMU_M4S4_SW_PD                  		((uint32_t) (0x00000010))
+#define PMU_M4S5_SW_PD                  		((uint32_t) (0x00000020))
+#define PMU_M4S6_SW_PD                  		((uint32_t) (0x00000040))
+#define PMU_M4S7_SW_PD                  		((uint32_t) (0x00000080))
+#define PMU_M4S8_SW_PD                  		((uint32_t) (0x00000100))
+#define PMU_M4S9_SW_PD                  		((uint32_t) (0x00000200))
+#define PMU_M4S10_SW_PD                  		((uint32_t) (0x00000400))
+#define PMU_M4S11_SW_PD                  		((uint32_t) (0x00000800))
+#define PMU_M4S12_SW_PD                  		((uint32_t) (0x00001000))
+#define PMU_M4S13_SW_PD                  		((uint32_t) (0x00002000))
+#define PMU_M4S14_SW_PD                  		((uint32_t) (0x00004000))
+#define PMU_M4S15_SW_PD                  		((uint32_t) (0x00008000))
+
+#define PMU_M4S0_SW_WU                  		((uint32_t) (0x00000001))
+#define PMU_M4S1_SW_WU                  		((uint32_t) (0x00000002))
+#define PMU_M4S2_SW_WU                  		((uint32_t) (0x00000004))
+#define PMU_M4S3_SW_WU                  		((uint32_t) (0x00000008))
+#define PMU_M4S4_SW_WU                  		((uint32_t) (0x00000010))
+#define PMU_M4S5_SW_WU                  		((uint32_t) (0x00000020))
+#define PMU_M4S6_SW_WU                  		((uint32_t) (0x00000040))
+#define PMU_M4S7_SW_WU                  		((uint32_t) (0x00000080))
+#define PMU_M4S8_SW_WU                  		((uint32_t) (0x00000100))
+#define PMU_M4S9_SW_WU                  		((uint32_t) (0x00000200))
+#define PMU_M4S10_SW_WU                  		((uint32_t) (0x00000400))
+#define PMU_M4S11_SW_WU                  		((uint32_t) (0x00000800))
+#define PMU_M4S12_SW_WU                  		((uint32_t) (0x00001000))
+#define PMU_M4S13_SW_WU                  		((uint32_t) (0x00002000))
+#define PMU_M4S14_SW_WU                  		((uint32_t) (0x00004000))
+#define PMU_M4S15_SW_WU                  		((uint32_t) (0x00008000))
+
+#define PMU_AUDIO0_EVENT_WU                 		((uint32_t) (0x00000001))
+#define PMU_AUDIO1_EVENT_WU                 		((uint32_t) (0x00000002))
+#define PMU_AUDIO2_EVENT_WU                 		((uint32_t) (0x00000004))
+#define PMU_AUDIO3_EVENT_WU                 		((uint32_t) (0x00000008))
+#define PMU_AUDIO4_EVENT_WU                 		((uint32_t) (0x00000010))
+#define PMU_AUDIO5_EVENT_WU                 		((uint32_t) (0x00000020))
+
+
+#define PMU_M4_STATUS_WU                			((uint32_t) (0x00000001))
+#define PMU_M4_STATUS_PD               				((uint32_t) (0x00000004))
+
+#define PMU_M4_SHUTDOWN_MODE           				((uint32_t) (0x00000002))
+#define PMU_M4S0_POWER_MODE            				((uint32_t) (0x00000002))
+
+#define PMU_M4SRAM_LPMF								((uint32_t) (0x00000002))
+#define PMU_M4SRAM_LPMH             				((uint32_t) (0x00000002))
+
+#define PWR_DWN_SCH_M4S0_PD              			((uint32_t) (0x00000080))
+#define PWR_DWN_SCH_AUDIO_PD              			((uint32_t) (0x00000040))
+#define PWR_DWN_SCH_SRAM_PD              			((uint32_t) (0x00000020))
+#define PWR_DWN_SCH_FFEFB_PD              			((uint32_t) (0x00000010))
+#define PWR_DWN_SCH_M4M4S0_WU              			((uint32_t) (0x00000008))
+#define PWR_DWN_SCH_AUDIO_WU              			((uint32_t) (0x00000004))
+#define PWR_DWN_SCH_SRAM_WU              			((uint32_t) (0x00000002))
+#define PWR_DWN_SCH_FFEFB_WU              			((uint32_t) (0x00000001))
+
+#define PWR_SDMA_SRAM_PD_CFG              			((uint32_t) (0x00040000))
+
+#define PWR_AUDIO_SRAM_CFG              			((uint32_t) (0x00000100))
+
+#define PWR_AUDIO_SRAM_LC_DS_R2              		((uint32_t) (0x00000004))
+#define PWR_AUDIO_SRAM_LC_DS_R1              		((uint32_t) (0x00000002))
+#define PWR_AUDIO_SRAM_LC_DS_R0              		((uint32_t) (0x00000001))
+
+#define M4_SRAM0_PD_WU				(uint32_t)(0x1)
+#define M4_SRAM1_PD_WU				(uint32_t)(0x2)
+#define M4_SRAM2_PD_WU				(uint32_t)(0x4)
+#define M4_SRAM3_PD_WU				(uint32_t)(0x8)
+#define M4_SRAM4_PD_WU				(uint32_t)(0x10)
+#define M4_SRAM5_PD_WU				(uint32_t)(0x20)
+#define M4_SRAM6_PD_WU				(uint32_t)(0x40)
+#define M4_SRAM7_PD_WU				(uint32_t)(0x80)
+#define M4_SRAM8_PD_WU				(uint32_t)(0x100)
+#define M4_SRAM9_PD_WU				(uint32_t)(0x200)
+#define M4_SRAM10_PD_WU				(uint32_t)(0x400)
+#define M4_SRAM11_PD_WU				(uint32_t)(0x800)
+#define M4_SRAM12_PD_WU				(uint32_t)(0x1000)
+#define M4_SRAM13_PD_WU				(uint32_t)(0x2000)
+#define M4_SRAM14_PD_WU				(uint32_t)(0x4000)
+#define M4_SRAM15_PD_WU				(uint32_t)(0x8000)
+
+
+#define SDMA_SW_PD_WU				(uint32_t)(0x1)
+#define EFUSE_SW_PD_WU				(uint32_t)(0x2)
+#define I2S_SW_PD_WU				(uint32_t)(0x20)
+#define A1_SW_PD_WU					(uint32_t)(0x40)
+
+#define AUDIO_AD0_PD_WU				(uint32_t)(0x1)
+#define AUDIO_AD1_PD_WU				(uint32_t)(0x2)
+#define AUDIO_AD2_PD_WU				(uint32_t)(0x4)
+#define AUDIO_AD3_PD_WU				(uint32_t)(0x8)
+#define AUDIO_AD4_PD_WU				(uint32_t)(0x10)
+#define AUDIO_AD5_PD_WU				(uint32_t)(0x20)
+
+
+/******************************************************************************
+ *                                  MISC                                      *
+ ******************************************************************************/
+#define MISC_LOCK_KEY                               ((uint32_t)(0x1ACCE551))
+
+/******************************************************************************
+ *                                SDMA_SRAM                                   *
+ ******************************************************************************/
+#define SDMA_SRAM_DST_INC_BYTE                      ((uint32_t) (0x00000000))
+#define SDMA_SRAM_DST_INC_HWORD                     ((uint32_t) (0x40000000))
+#define SDMA_SRAM_DST_INC_WORD                      ((uint32_t) (0x80000000))
+#define SDMA_SRAM_DST_SZ_BYTE                       ((uint32_t) (0x00000000))
+#define SDMA_SRAM_DST_SZ_HWORD                      ((uint32_t) (0x10000000))
+#define SDMA_SRAM_DST_SZ_WORD                       ((uint32_t) (0x20000000))
+
+#define SDMA_SRAM_SRC_INC_BYTE                      ((uint32_t) (0x00000000))
+#define SDMA_SRAM_SRC_INC_HWORD                     ((uint32_t) (0x04000000))
+#define SDMA_SRAM_SRC_INC_WORD                      ((uint32_t) (0x08000000))
+#define SDMA_SRAM_SRC_SZ_BYTE                       ((uint32_t) (0x00000000))
+#define SDMA_SRAM_SRC_SZ_HWORD                      ((uint32_t) (0x01000000))
+#define SDMA_SRAM_SRC_SZ_WORD                       ((uint32_t) (0x02000000))
+
+#define SDMA_SRAM_CH_CFG_DST_CACHABLE               ((uint32_t) (0x00800000))
+#define SDMA_SRAM_CH_CFG_DST_BUFFABLE               ((uint32_t) (0x00400000))
+#define SDMA_SRAM_CH_CFG_DST_PRIVILEGED             ((uint32_t) (0x00200000))
+
+#define SDMA_SRAM_CH_CFG_SRC_CACHABLE               ((uint32_t) (0x00100000))
+#define SDMA_SRAM_CH_CFG_SRC_BUFFABLE               ((uint32_t) (0x00080000))
+#define SDMA_SRAM_CH_CFG_SRC_PRIVILEGED             ((uint32_t) (0x00040000))
+
+#define SDMA_SRAM_R_POWER_0                         ((uint32_t) (0x00000000))
+#define SDMA_SRAM_R_POWER_2                         ((uint32_t) (0x00004000))
+#define SDMA_SRAM_R_POWER_4                         ((uint32_t) (0x00008000))
+#define SDMA_SRAM_R_POWER_8                         ((uint32_t) (0x0000C000))
+#define SDMA_SRAM_R_POWER_16                        ((uint32_t) (0x00010000))
+#define SDMA_SRAM_R_POWER_32                        ((uint32_t) (0x00014000))
+#define SDMA_SRAM_R_POWER_64                        ((uint32_t) (0x00018000))
+#define SDMA_SRAM_R_POWER_128                       ((uint32_t) (0x0001C000))
+#define SDMA_SRAM_R_POWER_256                       ((uint32_t) (0x00020000))
+#define SDMA_SRAM_R_POWER_512                       ((uint32_t) (0x00024000))
+#define SDMA_SRAM_R_POWER_NO                        ((uint32_t) (0x0003C000))
+
+#define SDMA_SRAM_N_MINUS_1_SHIFT                   ((uint32_t) 4)
+#define SDMA_SRAM_NEXT_USEBURST                     ((uint32_t) (0x00000008))
+
+#define SDMA_SRAM_CYCLE_CTRL_STOP                   ((uint32_t) (0x00000000))
+#define SDMA_SRAM_CYCLE_CTRL_BASIC                  ((uint32_t) (0x00000001))
+#define SDMA_SRAM_CYCLE_CTRL_AUTO_REQUEST           ((uint32_t) (0x00000002))
+#define SDMA_SRAM_CYCLE_CTRL_PING_PONG              ((uint32_t) (0x00000003))
+#define SDMA_SRAM_CYCLE_CTRL_PRI_SCATTER            ((uint32_t) (0x00000004))
+#define SDMA_SRAM_CYCLE_CTRL_ALT_SCATTER            ((uint32_t) (0x00000005))
+#define SDMA_SRAM_CYCLE_CTRL_PERI_SCATTER           ((uint32_t) (0x00000006))
+#define SDMA_SRAM_CYCLE_CTRL_ALT_PERI_SCATTER       ((uint32_t) (0x00000007))
+
+#define SDMA_SRAM_CH0                        (0)
+#define SDMA_SRAM_CH1                        (1)
+#define SDMA_SRAM_CH2                        (2)
+#define SDMA_SRAM_CH3                        (3)
+#define SDMA_SRAM_CH4                        (4)
+#define SDMA_SRAM_CH5                        (5)
+#define SDMA_SRAM_CH6                        (6)
+#define SDMA_SRAM_CH7                        (7)
+#define SDMA_SRAM_CH8                        (8)
+#define SDMA_SRAM_CH9                        (9)
+#define SDMA_SRAM_CH10                       (10)
+#define SDMA_SRAM_CH11                       (11)
+#define SDMA_SRAM_CH12                       (12)
+#define SDMA_SRAM_CH13                       (13)
+#define SDMA_SRAM_CH14                       (14)
+#define SDMA_SRAM_CH15                       (15)
+
+/******************************************************************************
+ *                              SDMA_BRIDGE                                   *
+ ******************************************************************************/
+#define SDMA_BRIDGE_SINGLE_REQ_SHIFT                ((uint32_t) 27)
+#define SDMA_BRIDGE_BURST_REQ_SHIFT                 ((uint32_t) 0)
+#define SDMA_BRIDGE_CH1_SELECT                      ((uint32_t) (1 << 0))
+#define SDMA_BRIDGE_CH2_SELECT                      ((uint32_t) (1 << 1))
+#define SDMA_BRIDGE_CH3_SELECT                      ((uint32_t) (1 << 2))
+#define SDMA_BRIDGE_CH4_SELECT                      ((uint32_t) (1 << 3))
+#define SDMA_BRIDGE_CH5_SELECT                      ((uint32_t) (1 << 4))
+#define SDMA_BRIDGE_CH6_SELECT                      ((uint32_t) (1 << 5))
+#define SDMA_BRIDGE_CH7_SELECT                      ((uint32_t) (1 << 6))
+#define SDMA_BRIDGE_CH8_SELECT                      ((uint32_t) (1 << 7))
+#define SDMA_BRIDGE_CH9_SELECT                      ((uint32_t) (1 << 8))
+#define SDMA_BRIDGE_CH10_SELECT                     ((uint32_t) (1 << 9))
+#define SDMA_BRIDGE_CH11_SELECT                     ((uint32_t) (1 << 10))
+
+/******************************************************************************
+ *                                  SDMA                                      *
+ ******************************************************************************/
+#define SDMA_DMA_STATUS_TEST_STATUS_SHIFT           ((uint32_t) 28)
+#define SDMA_DMA_STATUS_CHNLS_MINUS_1_SHIFT         ((uint32_t) 16)
+#define SDMA_DMA_STATUS_STATE_MASK                  ((uint32_t) 0x000000F0)
+#define SDMA_DMA_STATUS_IDLE_STATE                  ((uint32_t) 0x00000000)
+#define SDMA_DMA_STATUS_RD_CH_CTRL_DATA_STATE       ((uint32_t) 0x00000010)
+#define SDMA_DMA_STATUS_RD_SRC_DATA_PTR_STATE       ((uint32_t) 0x00000020)
+#define SDMA_DMA_STATUS_RD_DEST_DATA_PTR_STATE      ((uint32_t) 0x00000030)
+#define SDMA_DMA_STATUS_RD_SRC_DATA_STATE           ((uint32_t) 0x00000040)
+#define SDMA_DMA_STATUS_WR_DEST_DATA_STATE          ((uint32_t) 0x00000050)
+#define SDMA_DMA_STATUS_WAIT_DMA_STATE              ((uint32_t) 0x00000060)
+#define SDMA_DMA_STATUS_WR_CH_CTRL_DATA_STATE       ((uint32_t) 0x00000070)
+#define SDMA_DMA_STATUS_STALLED_STATE               ((uint32_t) 0x00000080)
+#define SDMA_DMA_STATUS_DONE_STATE                  ((uint32_t) 0x00000090)
+#define SDMA_DMA_STATUS_SCATTER_GATHER_STATE        ((uint32_t) 0x000000A0)
+#define SDMA_DMA_STATUS_MASTER_ENABLE               ((uint32_t) 0x00000001)
+
+#define SDMA_DMA_CFG_HPROT3_SET                     ((uint32_t) 0x00000080)
+#define SDMA_DMA_CFG_HPROT2_SET                     ((uint32_t) 0x00000040)
+#define SDMA_DMA_CFG_HPROT1_SET                     ((uint32_t) 0x00000020)
+#define SDMA_DMA_CFG_MASTER_ENABLE                  ((uint32_t) 0x00000001)
+
+#define SDMA_DMA_CH0_SELECT                         ((uint32_t) (1 << 0))
+#define SDMA_DMA_CH1_SELECT                         ((uint32_t) (1 << 1))
+#define SDMA_DMA_CH2_SELECT                         ((uint32_t) (1 << 2))
+#define SDMA_DMA_CH3_SELECT                         ((uint32_t) (1 << 3))
+#define SDMA_DMA_CH4_SELECT                         ((uint32_t) (1 << 4))
+#define SDMA_DMA_CH5_SELECT                         ((uint32_t) (1 << 5))
+#define SDMA_DMA_CH6_SELECT                         ((uint32_t) (1 << 6))
+#define SDMA_DMA_CH7_SELECT                         ((uint32_t) (1 << 7))
+#define SDMA_DMA_CH8_SELECT                         ((uint32_t) (1 << 8))
+#define SDMA_DMA_CH9_SELECT                         ((uint32_t) (1 << 9))
+#define SDMA_DMA_CH10_SELECT                        ((uint32_t) (1 << 10))
+#define SDMA_DMA_CH11_SELECT                        ((uint32_t) (1 << 11))
+#define SDMA_DMA_CH12_SELECT                        ((uint32_t) (1 << 12))
+#define SDMA_DMA_CH13_SELECT                        ((uint32_t) (1 << 13))
+#define SDMA_DMA_CH14_SELECT                        ((uint32_t) (1 << 14))
+#define SDMA_DMA_CH15_SELECT                        ((uint32_t) (1 << 15))
+
+/******************************************************************************
+ *                                  AIP                                       *
+ ******************************************************************************/
+#define AIP_OSC_CTRL_EN                 	((uint32_t) (0x00000001))
+#define AIP_OSC_CTRL_FRE_SEL              	((uint32_t) (0x00000002))
+
+/******************************************************************************
+ * 				    CRU                                       *
+ ******************************************************************************/
+#define CLK_CTRL_CLK_DIVIDER_ENABLE                 ((uint32_t) (0x00000200))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_2                ((uint32_t) (0x00000000))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_3                ((uint32_t) (0x00000001))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_4                ((uint32_t) (0x00000002))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_5                ((uint32_t) (0x00000003))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_6                ((uint32_t) (0x00000004))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_7                ((uint32_t) (0x00000005))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_8                ((uint32_t) (0x00000006))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_9                ((uint32_t) (0x00000007))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_10               ((uint32_t) (0x00000008))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_11               ((uint32_t) (0x00000009))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_12               ((uint32_t) (0x0000000A))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_13               ((uint32_t) (0x0000000B))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_14               ((uint32_t) (0x0000000C))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_15               ((uint32_t) (0x0000000D))
+#define CLK_CTRL_CLK_DIVIDER_RATIO_16               ((uint32_t) (0x0000000E))
+
+#define CLK_CTRL_A_CLK_SOURCE_SEL_HSPEED         ((uint32_t) (0x00000000))
+#define CLK_CTRL_A_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+#define CLK_CTRL_B_CLK_SOURCE_SEL_HSPEED            ((uint32_t) (0x00000000))
+#define CLK_CTRL_B_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+#define CLK_CTRL_E_CLK_SOURCE_SEL_HSPEED            ((uint32_t) (0x00000000))
+#define CLK_CTRL_E_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+#define CLK_CTRL_F_CLK_SOURCE_SEL_HSPEED            ((uint32_t) (0x00000000))
+#define CLK_CTRL_F_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+#define CLK_CTRL_H_CLK_SOURCE_SEL_HSPEED            ((uint32_t) (0x00000000))
+#define CLK_CTRL_H_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+#define CLK_CTRL_I_CLK_SOURCE_SEL_HSPEED            ((uint32_t) (0x00000000))
+#define CLK_CTRL_I_CLK_SOURCE_SEL_32KHZ             ((uint32_t) (0x00000001))
+
+#define HSPEED_CLK_SOURCE_SEL_FROM_OSC              ((uint32_t) (0x00000000))
+#define HSPEED_CLK_SOURCE_SEL_FROM_PAD              ((uint32_t) (0x00000001))
+
+#define C01_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C01_CLK_GATE_PATH_1_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_1_ON                      ((uint32_t) (0x00000002))
+#define C01_CLK_GATE_PATH_2_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_2_ON                      ((uint32_t) (0x00000004))
+#define C01_CLK_GATE_PATH_3_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_3_ON                      ((uint32_t) (0x00000008))
+#define C01_CLK_GATE_PATH_4_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_4_ON                      ((uint32_t) (0x00000010))
+#define C01_CLK_GATE_PATH_5_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_5_ON                      ((uint32_t) (0x00000020))
+#define C01_CLK_GATE_PATH_6_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_6_ON                      ((uint32_t) (0x00000040))
+#define C01_CLK_GATE_PATH_7_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_7_ON                      ((uint32_t) (0x00000080))
+#define C01_CLK_GATE_PATH_8_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_8_ON                      ((uint32_t) (0x00000100))
+#define C01_CLK_GATE_PATH_9_OFF                     ((uint32_t) (0x00000000))
+#define C01_CLK_GATE_PATH_9_ON                      ((uint32_t) (0x00000200))
+
+#define C02_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C02_CLK_GATE_PATH_1_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_1_ON                      ((uint32_t) (0x00000002))
+#define C02_CLK_GATE_PATH_2_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_2_ON                      ((uint32_t) (0x00000004))
+#define C02_CLK_GATE_PATH_3_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_3_ON                      ((uint32_t) (0x00000008))
+#define C02_CLK_GATE_PATH_4_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_4_ON                      ((uint32_t) (0x00000010))
+#define C02_CLK_GATE_PATH_5_OFF                     ((uint32_t) (0x00000000))
+#define C02_CLK_GATE_PATH_5_ON                      ((uint32_t) (0x00000020))
+
+#define C08_X4_CLK_GATE_PATH_0_OFF                  ((uint32_t) (0x00000000))
+#define C08_X4_CLK_GATE_PATH_0_ON                   ((uint32_t) (0x00000001))
+
+#define C08_X1_CLK_GATE_PATH_0_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_0_ON                   ((uint32_t) (0x00000001))
+#define C08_X1_CLK_GATE_PATH_1_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_1_ON                   ((uint32_t) (0x00000002))
+#define C08_X1_CLK_GATE_PATH_2_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_2_ON                   ((uint32_t) (0x00000004))
+#define C08_X1_CLK_GATE_PATH_3_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_3_ON                   ((uint32_t) (0x00000008))
+#define C08_X1_CLK_GATE_PATH_4_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_4_ON                   ((uint32_t) (0x00000010))
+#define C08_X1_CLK_GATE_PATH_5_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_5_ON                   ((uint32_t) (0x00000020))
+#define C08_X1_CLK_GATE_PATH_6_OFF                  ((uint32_t) (0x00000000))
+#define C08_X1_CLK_GATE_PATH_6_ON                   ((uint32_t) (0x00000040))
+
+#define C10_FCLK_GATE_PATH_0_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_0_ON                     ((uint32_t) (0x00000001))
+#define C10_FCLK_GATE_PATH_1_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_1_ON                     ((uint32_t) (0x00000002))
+#define C10_FCLK_GATE_PATH_2_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_2_ON                     ((uint32_t) (0x00000004))
+#define C10_FCLK_GATE_PATH_3_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_3_ON                     ((uint32_t) (0x00000008))
+#define C10_FCLK_GATE_PATH_4_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_4_ON                     ((uint32_t) (0x00000010))
+#define C10_FCLK_GATE_PATH_5_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_5_ON                     ((uint32_t) (0x00000020))
+#define C10_FCLK_GATE_PATH_6_OFF                    ((uint32_t) (0x00000000))
+#define C10_FCLK_GATE_PATH_6_ON                     ((uint32_t) (0x00000040))
+
+#define C11_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C11_CLK_GATE_PATH_1_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_1_ON                      ((uint32_t) (0x00000002))
+#define C11_CLK_GATE_PATH_2_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_2_ON                      ((uint32_t) (0x00000004))
+#define C11_CLK_GATE_PATH_3_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_3_ON                      ((uint32_t) (0x00000008))
+#define C11_CLK_GATE_PATH_4_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_4_ON                      ((uint32_t) (0x00000010))
+#define C11_CLK_GATE_PATH_5_OFF                     ((uint32_t) (0x00000000))
+#define C11_CLK_GATE_PATH_5_ON                      ((uint32_t) (0x00000020))
+
+#define C12_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C12_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C12_CLK_GATE_PATH_1_OFF                     ((uint32_t) (0x00000000))
+#define C12_CLK_GATE_PATH_1_ON                      ((uint32_t) (0x00000002))
+
+#define CS_CLK_GATE_PATH_0_OFF                      ((uint32_t) (0x00000000))
+#define CS_CLK_GATE_PATH_0_ON                       ((uint32_t) (0x00000001))
+
+#define CU_CLK_GATE_PATH_0_OFF                      ((uint32_t) (0x00000000))
+#define CU_CLK_GATE_PATH_0_ON                       ((uint32_t) (0x00000001))
+#define CU_CLK_GATE_PATH_1_OFF                      ((uint32_t) (0x00000000))
+#define CU_CLK_GATE_PATH_1_ON                       ((uint32_t) (0x00000002))
+
+#define C16_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C16_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C18_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C18_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C19_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C19_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C21_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C21_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+
+#define C22_CLK_CTRL_GATE_CTRL_OFF                  ((uint32_t) (0x00000000))
+#define C22_CLK_CTRL_GATE_CTRL_ON                   ((uint32_t) (0x00000001))
+#define C22_CLK_CTRL_SOURCE_SEL_I2S                 ((uint32_t) (0x00000000))
+#define C22_CLK_CTRL_SOURCE_SEL_PDM                 ((uint32_t) (0x00000002))
+
+#define FB_C21_DOMAIN_SW_RESET                      ((uint32_t) (0x00000020))
+#define FB_C16_DOMAIN_SW_RESET                      ((uint32_t) (0x00000010))
+#define FB_C09_DOMAIN_SW_RESET                      ((uint32_t) (0x00000004))
+#define FB_C02_DOMAIN_SW_RESET                      ((uint32_t) (0x00000001))
+
+#define C09_CLK_GATE_PATH_0_OFF                     ((uint32_t) (0x00000000))
+#define C09_CLK_GATE_PATH_0_ON                      ((uint32_t) (0x00000001))
+#define C09_CLK_GATE_PATH_1_OFF                     ((uint32_t) (0x00000000))
+#define C09_CLK_GATE_PATH_1_ON                      ((uint32_t) (0x00000002))
+#define C09_CLK_GATE_PATH_2_OFF                     ((uint32_t) (0x00000000))
+#define C09_CLK_GATE_PATH_2_ON                      ((uint32_t) (0x00000004))
+
+#define C30C31_CLK_CTRL_SOURCE_PDM_LEFT             ((uint32_t) (0x00000001))
+#define C30C31_CLK_CTRL_SOURCE_PDM_RIGHT            ((uint32_t) (0x00000002))
+
+#define CLK_DIVIDER_A_CG                            ((uint32_t) (0x00000001))
+#define CLK_DIVIDER_B_CG                            ((uint32_t) (0x00000002))
+#define CLK_DIVIDER_C_CG                            ((uint32_t) (0x00000004))
+#define CLK_DIVIDER_D_CG                            ((uint32_t) (0x00000008))
+#define CLK_DIVIDER_F_CG                            ((uint32_t) (0x00000020))
+#define CLK_DIVIDER_G_CG                            ((uint32_t) (0x00000040))
+#define CLK_DIVIDER_H_CG                            ((uint32_t) (0x00000080))
+#define CLK_DIVIDER_I_CG                            ((uint32_t) (0x00000100))
+#define CLK_DIVIDER_J_CG                            ((uint32_t) (0x00000200))
+
+/// @endcond EOSS3_DEV_MACROS
+
+#define REBOOT_CAUSE_HARDFAULT	(0x1)
+#define REBOOT_CAUSE_FLASHING	(0x2)
+#define REBOOT_CAUSE_SOFTFAULT	(0x3)
+#define REBOOT_CAUSE		(0xF)
+#define REBOOT_STATUS_REG	(PMU->MISC_POR_3)
+
+#endif /* __EOSS3_DEV_H */
+

--- a/HAL/inc/eoss3_hal_adc.h
+++ b/HAL/inc/eoss3_hal_adc.h
@@ -1,0 +1,30 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_adc.h
+ *    Purpose 	:  
+ *                                                          
+ * ===========================================================
+ *
+ */
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+typedef enum
+{
+  ADC_CHANNEL_0,
+  ADC_CHANNEL_1
+}ADC_channel;
+HAL_StatusTypeDef HAL_ADC_Init(ADC_channel channelNum,uint8_t enableBattMeasure);
+void HAL_ADC_StartConversion(void );
+HAL_StatusTypeDef HAL_ADC_GetData( uint16_t *pData);

--- a/HAL/inc/eoss3_hal_audio.h
+++ b/HAL/inc/eoss3_hal_audio.h
@@ -1,0 +1,194 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_audio.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __AUDIO_CORE_H_
+#define __AUDIO_CORE_H_
+#include <stdbool.h>
+
+#include "eoss3_dev.h"
+
+#ifndef PDM2DEC_FACT
+#define PDM2DEC_FACT 32
+#endif
+
+//PDM Core Config Registers Setting
+#define PDM_MODE_SEL            0       // 0=mono, 1=stereo
+#define PDM_MONO_CHN_SEL        0       // 0=left, 1=right if in mono mode
+//#define DEFAULT_PDM_PGA_L_VAL   8
+//#define DEFAULT_PDM_PGA_R_VAL   8
+#define DEFAULT_SOFT_MUTE       0
+
+#if     PDM2DEC_FACT==64
+
+#define  PDM2PCM_PGA_SYNC_RATE          (64)
+#define  PDM2PCM_PGA_GAIN_VAL           (6)
+#define  PDM2PCM_MCLKDIV_VAL            (0)
+#define  PDM2PCM_CLK_C30                (HSOSC_2MHZ)
+#define  PDM2PCM_CLK_C31                (HSOSC_512KHZ)
+
+#elif   PDM2DEC_FACT==48
+
+#define  PDM2PCM_PGA_SYNC_RATE          (48)
+#define  PDM2PCM_PGA_GAIN_VAL           (8)
+#define  PDM2PCM_MCLKDIV_VAL            (1)
+#define  PDM2PCM_CLK_C30                (HSOSC_3MHZ)
+#define  PDM2PCM_CLK_C31                (HSOSC_768KHZ)
+
+#elif   PDM2DEC_FACT==32
+
+#define  PDM2PCM_PGA_SYNC_RATE          (32)
+#define  PDM2PCM_PGA_GAIN_VAL           (16)
+#define  PDM2PCM_MCLKDIV_VAL            (1)
+#define  PDM2PCM_CLK_C30                (HSOSC_2MHZ)
+#define  PDM2PCM_CLK_C31                (HSOSC_512KHZ)
+
+#else
+#error "PDM2DEC_FACT is not defined "
+#endif
+
+#define PDM2PCM_DISABLE_HPF           (0)  
+#if PDM2PCM_DISABLE_HPF == 0
+#define PDM2PCM_HPF_HPGAIN            (5)
+#endif
+//PDM Voice Config Registers Setting
+enum VOICE_CONFIG_SCENARIO {
+  PDM_VOICE_SCENARIO1 = 0,
+  PDM_VOICE_SCENARIO2 = 1,
+  PDM_VOICE_SCENARIO3_MODE1 = 2,
+  PDM_VOICE_SCENARIO3_MODE2 = 3,
+  PDM_VOICE_SCENARIO3_MODE3 = 4
+};
+
+/** @brief Enumerators for audio errors */
+typedef enum {
+  AUDIO_ISR_EVENT_NO_BUFFER, ///< ISR could not obtain new buffer from FreeQ
+} audio_event_types_t;
+
+#define NO_SWITCH 0
+#define SWITCH_TO_AP 1
+
+#define DEFAULT_PDM_VOICE_SCENARIO PDM_VOICE_SCENARIO1
+#define DEFAULT_PDM_MIC_SWITCH_TO_AP NO_SWITCH
+
+#define AUDIO_ISR_MESSAGE  ( 0x0ff & ('A' + 'I' + 'S' + 'R') )
+#define AUDIO_TASK_MESSAGE  ( 0x0ff & ('T' + 'A' + 'S' + 'K') )
+
+
+struct connector {
+  bool initialized;
+  bool started;
+  void (*init)();
+  void (*start)();
+  void (*stop)();
+};
+
+typedef void* audio_handle_t;
+
+/*
+* DigitalMic type
+*/
+typedef enum DigitalMic {
+  DigitalMic_I2S,
+  DigitalMic_PDM,
+  DigitalMic_PDM_VoiceIQ
+} DigitalMic_t;
+
+/*
+* Event Notifier types
+*/
+typedef enum event_type {
+  HAL_Audio_Event_Start,
+  HAL_Audio_Event_LPSD_ON,
+  HAL_Audio_Event_LPSD_OFF,
+  HAL_Audio_Event_DMA_BLOCK_DONE,
+  HAL_Audio_Event_DMA_BUFFER_DONE,
+  HAL_Audio_Event_End
+} HAL_Audio_Event_type_t;
+
+/*
+* Get a handle for audio core by passing digital mic type.
+* Use this handle in all future calls.
+*/
+audio_handle_t HAL_Audio_GetHandle(DigitalMic_t micType);
+
+/*
+* Event Notifier prototype
+* Application can define this function and pass to HAL_Audio_Init API to get event callbacks.
+*/
+typedef void HAL_Audio_Event_Notifier_t(HAL_Audio_Event_type_t event_type, void *p_event_data);
+
+/*
+* Initialize audio core.
+* 	Turns on audio core
+* 	Sets all registers of audio core and other components such as CRU
+* 	Turns on interrupts at NVIC and M4 level, but audio core level interrupts are turned off
+*/
+void HAL_Audio_Init(audio_handle_t handle, HAL_Audio_Event_Notifier_t *pevent_notifier);
+
+/**
+* Starts audio core.
+* 	Enable the audio interrupts at audio core to stop audio capture
+*/
+void HAL_Audio_Start(audio_handle_t handle);
+
+/*
+* Stops audio core.
+* 	Disable the audio interrupts at audio core to stop audio capture
+*/
+void HAL_Audio_Stop(audio_handle_t handle);
+
+/**
+* Starts Audio DMA
+*/
+void HAL_Audio_StartDMA( void );
+
+/**
+* Stops Audio DMA
+*/
+void HAL_Audio_StopDMA( void );
+
+void release_data_block_prev(void);
+
+/**
+* Set LPSD module state
+* value : 1 to enable, 0 to disable
+*/
+void HAL_Audio_Set_LPSDMode(uint8_t value);
+
+// Audio Related isrs
+void HAL_Audio_ISR_LpsdOn();
+void HAL_Audio_ISR_LpsdOff();
+void onDmicOn();
+void onDmicOff();
+void onDmac0BlockDone();
+void onDmac0BufferDone();
+void HAL_Audio_Set_LPSDMode(uint8_t value);
+void handle_led_for_lpsd_on(void);
+void handle_led_for_lpsd_off(void);
+void handle_led_for_audio_stop(void);
+/** User application should define and instantiate the following structure */
+extern outQ_processor_t audio_isr_outq_processor ;
+
+void display_num_drop_count(void);
+void reset_num_drop_count(void);
+
+#endif /* __AUDIO_CORE_H_ */
+

--- a/HAL/inc/eoss3_hal_audio_config.h
+++ b/HAL/inc/eoss3_hal_audio_config.h
@@ -1,0 +1,123 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_audio_config.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_AUDIO_CONFIG_H__
+#define __EOSS3_HAL_AUDIO_CONFIG_H__
+
+#include "eoss3_hal_audio.h"
+
+#define QL_LPSD_THD_MASK 0xFFFF
+#define QL_LPSD_RATIO_STOP_MASK 0x00FF0000
+#define QL_LPSD_RATIO_RUN_MASK 0xFF000000
+
+enum QL_LPSD_CONFIG {
+	QL_LPSD_THD = 0,
+	QL_LPSD_RATIO_STOP = 16,
+        QL_LPSD_RATIO_RUN = 24,
+};
+
+typedef struct {
+  char run_start;
+  char run_stop;
+  short thr;
+}t_lpsd_mode_values;
+
+#define MAX_LPSD_MODES 10
+#define LPSD_DEFAULT_MODE 8
+
+
+void taskENTER_CRITICAL_todo();
+void taskEXIT_CRITICAL_todo();
+
+#define QL_AUDIO_HAL_ENTER_CRITICAL_SECTION(id) //taskENTER_CRITICAL()
+#define QL_AUDIO_HAL_EXIT_CRITICAL_SECTION(id)  //taskEXIT_CRITICAL()
+
+typedef enum voice_config_interrupts_e
+{
+  e_voice_config_interrupts_unmask_all = 0,
+  e_voice_config_interrupts_mask_all = 1
+}voice_config_interrupts_e;
+
+#define SRAM_ADDR_TO_DMA_ADDR(addr) ( SRAM_BASE | addr )
+#define AUDIO_SRAM_HW_DS_CFG (1<<8)
+#define DMAC_BLK_LEN   0
+#define DMAC_BUF_LEN   16
+
+t_lpsd_mode_values a_olpsd_mode_values[MAX_LPSD_MODES] = {
+  {
+    .run_start = 58,
+    .run_stop = 66,
+    .thr = 583,
+  },  //mode0
+  {
+    .run_start = 64,
+    .run_stop = 73,
+    .thr = 700
+  }, //mode1
+  {
+    .run_start = 70,
+    .run_stop = 80,
+    .thr = 830
+  }, //mode2
+  
+  {
+    .run_start = 77,
+    .run_stop = 88,
+    .thr = 1000,
+  }, //mode3
+  {
+    .run_start = 85,
+    .run_stop = 97,
+    .thr = 1200
+  }, //mode4
+  {
+    .run_start = 94,
+    .run_stop = 107,
+    .thr = 1440
+  }, //mode5
+  {
+    .run_start = 103,
+    .run_stop = 118,
+    .thr = 1728
+  }, //mode6
+  {
+    .run_start = 113,
+    .run_stop = 130,
+    .thr = 2074
+  }, //mode7
+  
+  {
+    .run_start = 77,
+    .run_stop = 80,
+    .thr = 1200
+  }, //mode8 default mode.
+  
+  {
+    .run_start = 77,
+    .run_stop = 88,
+    .thr = 1200
+  }, //mode9 Sensory recommended mode.
+  
+};
+
+
+#endif /* __EOSS3_HAL_AUDIO_CONFIG_H__ */
+

--- a/HAL/inc/eoss3_hal_audio_reg.h
+++ b/HAL/inc/eoss3_hal_audio_reg.h
@@ -1,0 +1,123 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_audio_reg.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_AUDIO_REG_H__
+#define __EOSS3_HAL_AUDIO_REG_H__
+#include <stdbool.h>
+
+/* VOICE_DMAC_CONFIG Register */
+typedef union ql_arch_voice_dmac_cfg_reg
+{
+    uint32_t voice_dmac_regVal;
+    struct
+    {
+        uint32_t   dmac_en:1;    /* LSB */
+        uint32_t   dmac_start:1;
+        uint32_t   dmac_stop:1;
+        uint32_t   ahb_rdy:1;
+        uint32_t   ahb_burst_length:2;
+        uint32_t   ping_pong_mode:1;
+        uint32_t   stereo_dual_buf_mode:1;
+        uint32_t   voice_dmac_burst_spd:8;
+        uint32_t   RESERVED:16;
+    }fields;
+}ql_arch_voice_dmac_cfg_reg;
+
+/* VOICE_CONFIG Register */
+typedef union ql_arch_voice_config_reg
+{
+    uint32_t vocie_config_regVal;
+    struct
+    {
+        uint32_t dmic_sel : 1;
+        uint32_t lpsd_sel : 1;
+        uint32_t mode_sel : 1;
+        uint32_t mono_chn_sel : 1;
+        uint32_t i2s_ds_en : 1;
+        uint32_t pdm_voice_scenario : 3;
+        uint32_t pdm_mic_switch_to_ap : 1;
+        uint32_t lpsd_use_dc_block : 1;
+        uint32_t lpsd_mux : 1;
+        uint32_t lpsd_no : 1;
+        uint32_t i2s_pga_en : 1;
+        uint32_t reserve1 : 2;
+        uint32_t div_ap : 3;
+        uint32_t div_wd : 6;
+        uint32_t fifo_0_clear : 1;
+        uint32_t fifo_1_clear : 1;
+        uint32_t lpsd_voice_detected_mask : 1;
+        uint32_t dmic_voice_detected_mask : 1;
+        uint32_t dmac_blk_done_mask : 1;
+        uint32_t dmac_buf_done_mask : 1;
+        uint32_t ap_pdm_clk_on_mask : 1;
+        uint32_t ap_pdm_clk_off_mask : 1;
+    }fields;
+}ql_arch_voice_config_reg;
+
+/* I2S_CONFIG Register */
+typedef union _t_ql_arch_i2s_config_reg
+{
+    uint32_t i2s_config_regVal;
+    struct
+    {
+      uint32_t i2s_lrcdiv   : 12;  // 0-11
+      uint32_t i2s_bclkdiv  : 6;  // 12-17
+      uint32_t i2s_clk_inv  : 1;
+      uint32_t i2s_iwl      : 1;
+      uint32_t RESERVED     : 11;
+    }fields;
+}ql_arch_i2s_config_reg;
+
+/* PDM_CORE_CONFIG register */
+typedef union ql_arch_core_pdm_config_reg
+{
+    uint32_t pdm_core_config_regVal;
+    struct
+    {
+        uint32_t pdmcore_en  :  1;
+        uint32_t soft_mute   :  1;
+        uint32_t div_mode    :  1;
+        uint32_t s_cycles    :  3;
+        uint32_t hpgain      :  4;
+        uint32_t adchpd      :  1;
+        uint32_t mclkdiv     :  2;
+        uint32_t sinc_rate   :  7;
+        uint32_t pga_l       :  5;
+        uint32_t pga_r       :  5;
+        uint32_t dmick_dly   :  1;
+        uint32_t div_wd_mode :  1;
+    }fields;
+}ql_arch_core_pdm_config_reg;
+
+/* LPSD_CONFIG Register */
+typedef union ql_arch_lpsd_config_reg
+{
+    uint32_t lpsd_config_regVal;
+    struct
+    {
+        uint32_t   lpsd_thd:16;
+        uint32_t   lpsd_ratio_stop:8;
+        uint32_t   lpsd_ratio_run:8;
+    }fields;
+}ql_arch_lpsd_config_reg;
+
+#endif /* __EOSS3_HAL_AUDIO_REG_H__ */
+

--- a/HAL/inc/eoss3_hal_def.h
+++ b/HAL/inc/eoss3_hal_def.h
@@ -1,0 +1,85 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_def.h
+ *    Purpose   : This file contains macros for HAL API status
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+/*!	\file eoss3_hal_def.h
+ *
+ *  Created on: Feb 15, 2016
+ *      Author: Rajkumar Thiagarajan
+ *
+ *  \brief .
+ */
+
+#ifndef HAL_INC_EOSS3_HAL_DEF_H_
+#define HAL_INC_EOSS3_HAL_DEF_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "test_types.h"
+/*! \enum HAL_StatusTypeDef
+ * \brief HAL Status values
+ */
+typedef enum
+{
+  HAL_OK       = 0x00,
+  HAL_ERROR    = 0x01,
+  HAL_BUSY     = 0x02,
+  HAL_TIMEOUT  = 0x03
+} HAL_StatusTypeDef;
+
+///@cond HAL_DEF_MACROS
+#define BYTE_IDX_0			(0x0)
+#define BYTE_IDX_1			(0x1)
+#define BYTE_IDX_2			(0x2)
+#define BYTE_IDX_3			(0x3)
+#define BYTE_IDX_4			(0x4)
+#define BYTE_IDX_5			(0x5)
+#define BYTE_IDX_6			(0x6)
+#define BYTE_IDX_7			(0x7)
+///@endcond
+
+typedef void (*HAL_FBISRfunction) (void);
+#define FB_INTERRUPT_0                  0
+#define FB_INTERRUPT_1                  1
+#define FB_INTERRUPT_2                  2
+#define FB_INTERRUPT_3                  3
+#define MAX_FB_INTERRUPTS               4
+
+#define FB_INTERRUPT_TYPE_LEVEL         0
+#define FB_INTERRUPT_TYPE_EDGE          1
+
+#define FB_INTERRUPT_POL_EDGE_FALL      0
+#define FB_INTERRUPT_POL_EDGE_RISE      1
+
+#define FB_INTERRUPT_POL_LEVEL_LOW      0
+#define FB_INTERRUPT_POL_LEVEL_HIGH     1
+
+#define FB_INTERRUPT_DEST_AP_ENABLE     1
+#define FB_INTERRUPT_DEST_AP_DISBLE     0    
+
+#define FB_INTERRUPT_DEST_M4_ENABLE     1
+#define FB_INTERRUPT_DEST_M4_DISBLE     0 
+
+void FB_RegisterISR(UINT32_t fbIrq, HAL_FBISRfunction ISRfn);
+void FB_ConfigureInterrupt(UINT32_t fbIrq, UINT8_t type, UINT8_t polarity, UINT8_t destAP,UINT8_t destM4 );
+
+    
+#endif /* HAL_INC_EOSS3_HAL_DEF_H_ */

--- a/HAL/inc/eoss3_hal_ffe.h
+++ b/HAL/inc/eoss3_hal_ffe.h
@@ -1,0 +1,414 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_ffe.h
+ *    Purpose 	: This file contains macros and APIs
+ *         for FFE
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_INC_EOSS3_HAL_FFE_H_
+#define HAL_INC_EOSS3_HAL_FFE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+
+/// @cond HAL_FFE_INTERNAL_MACROS
+
+/*! \def EXPORT_VAR_COUNT
+    \brief A macro to define export variable count.
+*/
+#define EXPORT_VAR_COUNT			  64
+
+/*! \def FFE_CFG_BASE
+    \brief A macro to define M4 SRAM offset which stores the export section.
+*/
+#define FFE_CFG_BASE				  0x2007F800
+//#define FFE_CFG_BASE				  0x2007FE80  //Export section parsing base address for new celeris patch [Syama]
+
+/*! \def ALGS_COUNT
+    \brief A macro to define algorithm count.
+*/
+#define ALGS_COUNT					  10
+
+/*! \def EXPO_FFE_MAILBOX1
+    \brief A macro to define export variable FFE_MAILBOX1.
+*/
+#define EXPO_FFE_MAILBOX1			  1
+
+/*! \def EXPO_FFE_MAILBOX2
+    \brief A macro to define export variable FFE_MAILBOX2.
+*/
+#define EXPO_FFE_MAILBOX2			  2
+
+/*! \def EXPO_SM_MAILBOX
+    \brief A macro to define export variable SM_MAILBOX.
+*/
+#define EXPO_SM_MAILBOX				  3
+
+/*! \def EXPO_FFE_TICK_MS
+    \brief A macro to define export variable FFE_TICK_MS.
+*/
+#define EXPO_FFE_TICK_MS			  4
+
+/*! \def EXPO_INTR_MASK
+    \brief A macro to define export variable INTR_MASK.
+*/
+#define EXPO_INTR_MASK				  5
+
+/*! \def EXPO_M4_REQ_STATE
+    \brief A macro to define export variable M4_REQ_STATE.
+*/
+#define EXPO_M4_REQ_STATE			  6
+
+/*! \def EXPO_FFE_RESP_STATE
+    \brief A macro to define export variable FFE_RESP_STATE.
+*/
+#define EXPO_FFE_RESP_STATE			  7
+
+/*! \def EXPO_ACCEL_POLL_FREQ
+    \brief A macro to define export variable ACCEL_POLL_FREQ.
+*/
+#define EXPO_ACCEL_POLL_FREQ		  8
+
+/*! \def EXPO_MAG_POLL_FREQ
+    \brief A macro to define export variable MAG_POLL_FREQ.
+*/
+#define EXPO_MAG_POLL_FREQ		  	  9
+
+/*! \def EXPO_GYRO_POLL_FREQ
+    \brief A macro to define export variable GYRO_POLL_FREQ.
+*/
+#define EXPO_GYRO_POLL_FREQ		  	  10
+
+/*! \def EXPO_DUMP
+    \brief A macro to define dump location for export structure.
+*/
+#define EXPO_DUMP					  63
+
+/*! \def ALG_CONFIG1_TYPE
+    \brief A macro to define algorithm structure type with single dependent sensor.
+*/
+#define ALG_CONFIG1_TYPE			 13
+
+/*! \def ALG_CONFIG2_TYPE
+    \brief A macro to define algorithm structure type with two dependent sensor.
+*/
+#define ALG_CONFIG2_TYPE			  15
+
+/*! \def EXPORT_VAR_LIMIT
+    \brief A macro to define export variable count.
+*/
+#define EXPORT_VAR_LIMIT			  0x64
+
+/*! \def MB1_SENSID_CUTOFF
+    \brief A macro to define Sensor Id cutoff for FFE Mailbox 1
+*/
+#define MB1_SENSID_CUTOFF			  0x30
+
+/*! \def UPDATE_MB1
+    \brief A macro to inform FFE Mailbox 1 needed to be updated.
+*/
+#define UPDATE_MB1					  0x81
+
+/*! \def UPDATE_MB2
+    \brief A macro to inform FFE Mailbox 2 needed to be updated.
+*/
+#define UPDATE_MB2					  0x82
+/*! \def SM0
+    \brief A macro to define SM type0.
+*/
+#define SM0							  0
+
+/*! \def SM1
+    \brief A macro to define SM type1.
+*/
+#define SM1							  1
+
+/// @endcond
+
+/// @cond HAL_FFE_INTERNAL_STRUCTURES
+/*! \struct xSensor_alg_config_1
+ *	\brief	Sensor Configuration Parameters for single sensor dependency
+ */
+typedef struct
+{
+	UINT32_t usSensor_Id;				/*!< Sensor Id */
+	UINT32_t usDep1_Sensor_Id;			/*!< Dependent Sensor Id */
+	UINT32_t usDep1_Sensor_Rate;		/*!< Dependent Sensor Rate*/
+	UINT32_t usFifo_op_addr;			/*!< Fifo output address */
+	UINT32_t usBatch_size;				/*!< Batching Size in bytes */
+	UINT32_t usBatch_flush;
+	UINT32_t usBatch_group_index;
+	UINT32_t uiBatching_Mode;
+	UINT32_t uiElapsed_Batch_Time;
+	UINT32_t uiBatched_Packet_Count;
+	UINT32_t usBG_Enable;				/*!< Always Enabled flag */
+	UINT32_t output_rate;				/*!< Algorithm Output Rate */
+	UINT32_t mb_value;					/*!< Mailbox Value */
+
+}xSensor_alg_config_1;
+
+/*! \struct xSensor_alg_config_2
+ *	\brief	Sensor Configuration Parameters for two sensor dependency
+ */
+typedef struct
+{
+	UINT32_t usSensor_Id;				/*!< Sensor Id */
+	UINT32_t usDep1_Sensor_Id;			/*!< Dependent1 Sensor Id */
+	UINT32_t usDep1_Sensor_Rate;		/*!< Dependent1 Sensor Rate*/
+	UINT32_t usDep2_Sensor_Id;			/*!< Dependent2 Sensor Id */
+	UINT32_t usDep2_Sensor_Rate;		/*!< Dependent2 Sensor Rate*/
+	UINT32_t usFifo_op_addr;			/*!< Fifo output address */
+	UINT32_t usBatch_size;				/*!< Batching Size in bytes */
+	UINT32_t usBatch_flush;
+	UINT32_t usBatch_group_index;
+	UINT32_t uiBatching_Mode;
+	UINT32_t uiElapsed_Batch_Time;
+	UINT32_t uiBatched_Packet_Count;
+	UINT32_t usBG_Enable;				/*!< Always Enabled flag */
+	UINT32_t output_rate;				/*!< Algorithm Output Rate */
+	UINT32_t mb_value;					/*!< Mailbox Value */
+
+}xSensor_alg_config_2;
+
+/*! \struct xExport_var_t
+ *	\brief	Export variable structure
+ */
+typedef struct
+{
+	UINT8_t 	ucId;		/*!< Export Section ID */
+	UINT8_t 	ucMemType;      /*!< Export Section Memory Type */
+	UINT16_t	usAddr;         /*!< Export Section Address offset */
+	UINT32_t 	ulLen;		/*!< Export Section length */
+
+}xExport_var_t;
+/// @endcond
+
+/*! \enum       eHAL_FFE_CmdType
+ *  \brief	HAL FFE Command Type
+ */
+typedef enum
+{
+	eFFE_SENSOR_ENABLE = 1,
+	eFFE_SENSOR_RATE_CHANGE,
+	eFFE_SENSOR_BATCH_SIZE,
+	eFFE_SENSOR_BATCH_FLUSH,
+	eFFE_SENSOR_OUTPUT_DISABLE
+}eHAL_FFE_CmdType;
+
+/*! \struct     FFE_FifoCfgTypeDef
+ *  \brief	HAL FIFO Configuration structure
+ */
+typedef struct
+{
+	UINT8_t			ucFifoSrc;			/*!< FIFO source */
+	UINT8_t			ucFifoDest;			/*!< FIFO destination */
+	UINT8_t			ucFifoType;			/*!< FIFO type */
+	UINT8_t 		ucIntSetting;		        /*!< FIFO Interrupt Settings */
+	UINT16_t		usPopThreshIntCnt;	        /*!< FIFO threshold in terms of words (32-bit) */
+	UINT16_t 		usPushThreshIntCnt;	        /*!< FIFO Push Threshold Interrupt Count */
+
+}FFE_FifoCfgTypeDef;
+
+/*! \struct     FFE_HandleTypeDef
+ *  \brief	HAL FFE Configuration structure
+ */
+typedef struct
+{
+	FFE_FifoCfgTypeDef			FifoCfg;						/*!< config parameters for FIFO */
+	UINT8_t 				ucRunOnce;						/*!< Flag to enable FFE to run in single step mode */
+	UINT8_t  				ucRunContinous;					        /*!< Flag to enable FFE to run in continuous mode */
+	UINT8_t  				ucStopFFE;						/*!< Flag to stop the FFE execution */
+	UINT8_t					ucHaltFFE;						/*!< Flag to halt the FFE execution */
+	UINT8_t					ucReleaseFFE;					        /*!< Flag to release the FFE halt */
+	UINT32_t 				ulRunCnt;						/*!< FFE run count */
+	UINT32_t 				ulFFEFreq;						/*!< FFE frequency */
+
+}FFE_HandleTypeDef;
+
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_GetAlgParams(UINT8_t usSensId,xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2);
+ * \brief 	This function returns the Alg configuration parameters
+ * \param 	ucSensId   --- sensor ID
+ * \param   config1    --- pointer to Config 1 structure
+ * \param	config2    --- pointer to Config 2 structure
+ * \return	HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_GetAlgParams(UINT8_t ucSensId,xSensor_alg_config_1 **config1,xSensor_alg_config_2 **config2);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_SetAlgParams(UINT8_t *ucBuf, UINT8_t ucCmdType)
+ * \brief 	This function configures the Alg parameters inside FFE
+ * \param 	ucBuf	     --- User Command buffer
+ * \param       ucCmdType    --- Command Type
+ * \return	HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_SetAlgParams(UINT8_t *ucBuf, UINT8_t ucCmdType);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_WriteMem(volatile UINT32_t *ulMem_addr, UINT32_t ulLen, void *buf)
+ * \brief 	This function write into FFE Data memory section
+ * \param 	ulMem_addr -- DM Memory Address
+ * \param 	ulLen 	   -- Number of bytes to write
+ * \param 	buf        -- Data buffer to write
+ * \return      HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_WriteMem32(volatile UINT32_t *ulMem_addr, UINT32_t value);
+
+HAL_StatusTypeDef HAL_FFE_WriteMem(volatile UINT32_t *ulMem_addr, UINT32_t ulLen, void *buf);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_ReadMem(volatile UINT32_t *ulMem_addr, UINT32_t ulLen, void *buf)
+ * \brief 	This function read from FFE Data memory section
+ * \param 	ulMem_addr -- DM Memory Address
+ * \param 	ulLen 	   -- Number of bytes to read
+ * \param 	buf        -- Data buffer to read
+ * \return      HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_ReadMem(volatile UINT32_t *ulMem_addr, UINT32_t ulLen, void *buf);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_Config(FFE_HandleTypeDef *hFFE)
+ * \brief 	This function configure the FFE 
+ * \param 	hFFE -- pointer to FFE Handle structure
+ * \return      HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_Config(FFE_HandleTypeDef *hFFE);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_Init(void)
+ * \brief 	This function initialize the FFE 
+ * \return      HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_Init(void);
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_FFE_DeInit(FFE_HandleTypeDef *hFFE)
+ * \brief 	This function deinitialize the FFE 
+ * \return      HAL Status
+ */
+HAL_StatusTypeDef HAL_FFE_DeInit(FFE_HandleTypeDef *hFFE);
+
+
+void HAL_FFE_ENABLE_INT(void);
+/// @cond HAL_FFE_INTERNAL_API
+
+/*!
+ * \fn          UINT32_t get_algsenabled_cnt(UINT32_t ulMailboxVal)
+ * \brief       Computes the total number of algorithms enabled based on mailbox value
+ * \param       ulMailboxVal -- Mailbox value
+ * \return      Alg count
+ */
+static UINT32_t FFE_GetAlgsEnabledCnt(UINT32_t ulMailboxVal);
+/*!
+ * \fn 	        void FFE_Compute_New_Samplerate(UINT16_t usMailbox)
+ * \brief       Based on mailbox value, it will check if any other algorithm is enabled,
+ *              if enabled then change the FFE sample time to the next max sample rate. *
+ * \param       usMailbox -- Mailbox bit.
+ */
+static void FFE_Compute_New_Samplerate(UINT16_t usMailbox);
+/*!
+ * \fn          void FFE_UpdateCfg(UINT8_t ucMbUpdate, xSensor_alg_config_1 *cfg1, xSensor_alg_config_2 *cfg2)
+ * \brief       This function updates the new FFE configuration.
+ * \param       ucMbUpdate -- Flag to set if Mailbox update is needed or not
+ * \param       *cfg1	   -- Pointer to Sensor_alg_Config1 structure
+ * \param       *cfg2 	   -- Pointer to Sensor_alg_config2 structure * 
+ */
+static void FFE_UpdateCfg(UINT8_t ucMbUpdate, xSensor_alg_config_1 *cfg1, xSensor_alg_config_2 *cfg2);
+/*!
+ * \fn          static HAL_StatusTypeDef FFE_Get_AlgConfig(UINT8_t ucId, xSensor_alg_config_1 **config_1, xSensor_alg_config_2 **config_2)
+ * \brief       Traverse through sensor config structure list to identify corresponding sensor configuration
+ * \param       Id      -- sensor ID
+ * \param       config1 -- pointer to sensor configuration for single dependency sensor
+ * \param       config2 -- pointer to sensor configuration for two dependency sensor
+ * \return      HAL Status
+ */
+static HAL_StatusTypeDef FFE_Get_AlgConfig(UINT8_t ucId, xSensor_alg_config_1 **config_1, xSensor_alg_config_2 **config_2);
+/*!
+ * \fn 		static HAL_StatusTypeDef FFE_Parse_ExpoSection(void)
+ * \brief 	This function parses the export variables section in M4 SRAM
+ * \param 	None
+ * \return      HAL Status
+ */
+static HAL_StatusTypeDef FFE_Parse_ExpoSection(void);
+/*!
+ * \fn 		static UINT8_t FFE_CheckBitEnable(UINT32_t ulVar)
+ * \brief 	Compute the enabled bit position from Mailbox value
+ * \param 	ulVar -- Algorithm mailbox value
+ * \return	bit index which is set to 1.
+ */
+static UINT8_t FFE_CheckBitEnable(UINT32_t ulVar);
+/*!
+ * \fn 		static void FFE_Get_SensIdInfo(UINT8_t *ucSensId)
+ * \brief 	Traverse through the alg structure and store the sensor IDs
+ * \brief 	in an array based on mailbox bit position
+ * \param 	ucSensID -- Sensor ID
+ */
+static void FFE_Get_SensIdInfo(UINT8_t *ucSensId);
+/*!
+ * \fn		static void FFE_Enable(UINT8_t ucEnable)
+ * \brief 	Function to enable power & clock domains for FFE subsystem
+ * \param	ucEnable --- Enable Flag
+ */
+static void FFE_Enable(UINT8_t ucEnable);
+/*!
+ * \fn 		static void FFE_Set_Sampletime(UINT16_t usTimeinMS)
+ * \brief 	This function sets the new FFE sample time
+ * \param 	usTimeinMS -- Sample Time in milliseconds
+ */
+static void FFE_Set_Sampletime(UINT16_t usTimeinMS);
+/*!
+ * \fn 		static void FFE_AlgEnable(UINT8_t *ucBuf,xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2)
+ * \brief	Function to enable the corresponding Algorithm inside FFE
+ * \param	ucBuf	---	User Command buffer
+ * \param	config1	--- pointer to alg config1 structure
+ * \param	config2	--- pointer to alg config2 structure
+ */
+static void FFE_AlgEnable(UINT8_t *ucBuf,xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2);
+/*!
+ * \fn 		static void FFE_SampleRateCfg(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2)
+ * \brief	Function to configure the FFE sample rate inside FFE
+ * \param	ucBuf	--- User Command buffer
+ * \param	config1	--- pointer to alg config1 structure
+ * \param	config2	--- pointer to alg config2 structure
+ */
+static void FFE_SampleRateCfg(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2);
+/*!
+ * \fn 		static void FFE_CfgBatchSize(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2)
+ * \brief	Function to configure the batch size inside FFE
+ * \param	ucBuf	--- User Command buffer
+ * \param	config1	--- pointer to alg config1 structure
+ * \param	config2	--- pointer to alg config2 structure
+ */
+static void FFE_CfgBatchSize(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2);
+/*!
+ * \fn 		static void FFE_AlgOutputCfg(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2)
+ * \brief	Function to configure the sensor packet output mode configure inside FFE
+ * \param	ucBuf	--- User Command buffer
+ * \param	config1	--- pointer to alg config1 structure
+ * \param	config2	--- pointer to alg config2 structure
+ */
+static void FFE_AlgOutputCfg(UINT8_t *ucBuf, xSensor_alg_config_1 *config1,xSensor_alg_config_2 *config2);
+/*!
+ * \fn 		static HAL_StatusTypeDef FFE_ConfigureSM(UINT8_t ucSM_type)
+ * \brief 	This function configures SM 0/1 SDA and SCL pads
+ * \param 	SM_type -- Sensor Manager type (SM0/SM1)
+ * \return	Status
+ */
+static HAL_StatusTypeDef FFE_ConfigureSM(UINT8_t ucSM_type);
+
+
+/// @endcond
+
+#endif /* HAL_INC_EOSS3_HAL_FFE_H_ */

--- a/HAL/inc/eoss3_hal_fpga_adc_api.h
+++ b/HAL/inc/eoss3_hal_fpga_adc_api.h
@@ -1,0 +1,91 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_adc_api.h
+ *    Purpose 	: This file contains ADC wrapper APIs to use by FPGA ADC IP drivers
+ *         for data transfer to and from FPGA ADC IP on S3.
+ *         These APIs can be used by only FPGA IP applications. 
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_EOSS3_HAL_FPGA_ADC_API_H_
+#define HAL_EOSS3_HAL_FPGA_ADC_API_H_
+
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+
+/* ADC LTC1859 command configuration.
+ * channelX_command 8 bit format as follows:
+ * bit 7:4->Channel Mux Address ==> Channel selection and Single/Differential config.
+ * bit 3:2->Input Range selection ==> Polarity and Gain of input signal.
+ * bit 1:0->Power down modes. [NAP:SLEEP]. Currently these bits are not supported.
+ * Each channel can be configured independently of others.
+ * Refere data sheet "LTC185x Datasheet.pdf" for details about these configuration.
+ */
+typedef struct __LTC1859_cfg_t
+{
+  uint32_t frequency;
+  /* today - we support 4 channels, future we might support 8 single ended */
+#define LTC1859_MAX_CHANNELS 8
+  uint8_t chnl_commands[LTC1859_MAX_CHANNELS];
+  uint8_t channel_enable_bits;
+
+} HAL_LTC1859_cfg_t;
+
+/* 
+ * This structure maps a "config" value
+ * into two things:
+ *   (1) A format char for the JSON data.
+ *   (2) conversion factors that convert the ADC count into uVolts.
+ */
+struct LTC1859_ymx_plus_b {
+     uint8_t masked_config_value;
+     char    python_format_char;
+     int8_t  is_signed;
+     int8_t  dummy_pad;
+     int32_t slopeM; /* multiplier */
+     int32_t slopeD; /* divisor */
+     int32_t intercept;
+};
+
+/* given a config value, return a valid conversion struct for the sensor value */
+const struct LTC1859_ymx_plus_b *HAL_LTC1859_CfgToYmxB( int config );
+int LTC1859_to_uVolts( uint8_t cfg, uint16_t value );
+
+/* Initilazation of FPGA ADC HAL driver.
+ * cfg -> pointer to filled configuration structure for adc channels.
+ * pcb_read is call back function which gets called when sensor data read is
+ * completed when HAL_FPGA_ADC_Read() is called.
+ * Returns Success/Failure.
+ */
+HAL_StatusTypeDef HAL_LTC1859_ADC_Init(HAL_LTC1859_cfg_t *cfg, void (*pcb_read)(void));
+
+/*
+ * API to read block of sensor data.
+ * Returns success/failure.
+ * This is non-blocking API, when it fills buffer, read call back will be called.
+ * Buffer length is expected to be multiple of 4 bytes. If buffer length is not
+ * multiple of 4 bytes, it will fill buffer upto nearest multiple of 4 [= n_bytes/4*4]
+ */
+HAL_StatusTypeDef HAL_LTC1859_ADC_Read(void *buffer, size_t n_bytes);
+
+/*
+ * API to release acquired resources.
+  */
+void HAL_LTC1859_ADC_De_Init(void);
+
+
+#endif //HAL_EOSS3_HAL_FPGA_ADC_API_H_

--- a/HAL/inc/eoss3_hal_fpga_adc_reg.h
+++ b/HAL/inc/eoss3_hal_fpga_adc_reg.h
@@ -1,0 +1,62 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_adc_reg.h
+ *    Purpose 	: This file contains Register definitions of FPGA ADC interface IP.
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef HAL_EOSS3_HAL_FPGA_ADC_REG_H_
+#define HAL_EOSS3_HAL_FPGA_ADC_REG_H_
+
+#define FPGA_ADC_BASE   (FPGA_PERIPH_BASE)
+
+/* FPGA AGC register definitions. */
+typedef struct
+{
+  __IO uint32_t CHIP_ID;        /*0x0  */    //IP DEVICE ID = {0x55ADC}
+  __IO uint32_t REV_NO;         /*0x4  */    //IP Revision number value = 0x0100 [version 1.0]
+  __IO uint32_t FIFO_RESET;     /*0x8  */    //RX FIFO FLUSH HW auto clear
+  __IO uint32_t SEN_ENR;        /*0xC  */    //Sensor Enable Register. Bit Mask for Sensor Channels
+  __IO uint32_t SEN1_SETTING;   /*0x10 */    //Sensor1 settings.
+  __IO uint32_t SEN2_SETTING;   /*0x14 */    //Sensor2 settings.
+  __IO uint32_t SEN3_SETTING;   /*0x18 */    //Sensor3 settings.
+  __IO uint32_t SEN4_SETTING;   /*0x1C */    //Sensor4 settings.
+  /* Timer works on C21 Clock (C21 = 2 MHz, SW setting, 0.5usec pulse) Load 0x100 for 16kHz, 0x29 for 100kHz*/
+  __IO uint32_t TIMER_COUNT;    /*0x20 */    //Time count for highest sampling rate.
+  __IO uint32_t TIMER_ENABLE;   /*0x24 */    //Timer Enable
+} FPGA_ADC_TypeDef;
+
+#define FPGA_ADC         ((FPGA_ADC_TypeDef *) FPGA_ADC_BASE)
+
+
+#define ADC_CHIP_ID_VAL (0x55ADC)
+#define SENSOR_SAMPLE_RATE_100KHZ  (100000)
+#define SENSOR_SAMPLE_RATE_16KHZ   (16000)
+
+#define SENSOR_SAMPLE_RATE_100KHZ_DIV_VALUE  (0x29)
+#define SENSOR_SAMPLE_RATE_16KHZ_DIV_VALUE  (0x100)
+
+#define FOUR_MEGA_HZ  (4096000)
+
+#define ADC_FIFO_RESET_BIT       (0x1)
+#define ADC_TIMER_ENABLE_BIT     (0x1)
+
+#define CHANNEL0_ENABLE_MASK     (0x1 << 0)
+#define CHANNEL1_ENABLE_MASK     (0x1 << 1)
+#define CHANNEL2_ENABLE_MASK     (0x1 << 2)
+#define CHANNEL3_ENABLE_MASK     (0x1 << 3)
+
+#endif //HAL_EOSS3_HAL_FPGA_ADC_REG_H_

--- a/HAL/inc/eoss3_hal_fpga_clk_sync.h
+++ b/HAL/inc/eoss3_hal_fpga_clk_sync.h
@@ -1,0 +1,132 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_clk_sync.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_FPGA_CLK_SYNC_H_
+#define __EOSS3_HAL_FPGA_CLK_SYNC_H_
+
+ /**
+ * @brief return value definitions
+ */
+ 
+#include <stdint.h>
+
+/**
+ * @brief return value definitions
+ */
+#define HAL_FB_CLK_SYNC_RET_VAL		(0x0)
+#define HAL_FB_CLK_SYNC_ERR			(0x20)
+
+#define HAL_FB_CLK_SYNC_SUCCESS		(HAL_FB_CLK_SYNC_ERR + 0x0)
+
+#define HAL_FB_CLK_SYNC_INIT_ERR		(HAL_FB_CLK_SYNC_ERR + 0x1)
+#define HAL_FB_CLK_SYNC_START_ERR		(HAL_FB_CLK_SYNC_ERR + 0x2)
+#define HAL_FB_CLK_SYNC_STOP_ERR		(HAL_FB_CLK_SYNC_ERR + 0x3)
+#define HAL_FB_CLK_SYNC_ADJUST_ERR		(HAL_FB_CLK_SYNC_ERR + 0x4)
+
+/* HS Oscillator frequency increase in multiple of 32 kHz */
+#define HAL_HSOSC_ADJ_UNIT				(32768 * 1)
+
+
+/* Sampling rate of word select clock, This is external clock from the other chip */
+#define HAL_FB_EXT_CLK_48KHZ			48000 /* External clock is 48 kHz */
+#define HAL_FB_EXT_CLK_32KHZ			32000 /* External clock is 32 kHz */
+#define HAL_FB_EXT_CLK_16KHZ			16000 /* External clock is 16 kHz */
+
+/**
+ * @brief HSOSC clock synchronization structure
+ */
+typedef struct
+{
+    uint16_t sampling_freq;     /* Sampling frequency of external clock */
+    uint32_t clk_osc; 		/* Clock oscialltor adjustment unit */
+} FB_clk_sync_Cfg_t;
+
+/**
+ * @brief HAL_FB_Clk_Sync_init Clock synchronization initialization.
+ *
+ * @param[in] clksync_cfg, configurations for clock sync.
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *                  In case of failure returns HAL_FB_CLK_SYNC_INIT_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_init (FB_clk_sync_Cfg_t clksync_cfg);
+
+/**
+ * @brief HAL_FB_Clk_Sync_start this API will enable the FB Clocks and enables the
+ *              clock synchronization flag
+ *
+ * @param[in] void
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *                  In case of failure returns HAL_FB_CLK_SYNC_START_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_start (void);
+
+/**
+ * @brief HAL_FB_Clk_Sync_adjust this API will check the sample count and re-adjust clock
+ *          if there is any difference in the samples. This has to be called every time when
+ *          the data arrives. To be called from dma handler.
+ *
+ * @param[out] difference in samples
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *                  In case of failure returns HAL_FB_CLK_SYNC_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_adjust (int32_t *adjust_unit);
+
+/**
+ * @brief HAL_FB_Clk_Sync_stop This API will disable the FB Clock and disables
+ *          clock synchronization
+ *
+ * @param[in] void
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *      In case of failure returns HAL_FB_CLK_SYNC_STOP_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_stop (void);
+
+/**
+ * @brief HAL_FB_Clk_Sync_Reset_counter This API will reset the I2S, MIC counter
+ *              and the clock synchronization starts again.
+ *
+ * @param[in] void
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *                  In case of failure returns HAL_FB_CLK_SYNC_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_Reset_counter (void);
+
+/**
+ * @brief HAL_FB_Clk_Sync_uninit This API will uninit the clock synchronization
+ * process.
+ *
+ * @param[in] void
+ *
+ * @retval uint32_t, Returns a HAL_FB_CLK_SYNC_SUCCESS in case of success.
+ *                  In case of failure returns HAL_FB_CLK_SYNC_ERR.
+ *
+ */
+uint32_t HAL_FB_Clk_Sync_uninit (void);
+#endif /* __EOSS3_HAL_FPGA_CLK_SYNC_H_ */

--- a/HAL/inc/eoss3_hal_fpga_gpio.h
+++ b/HAL/inc/eoss3_hal_fpga_gpio.h
@@ -1,0 +1,116 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_gpio.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+ 
+#ifndef __EOSS3_HAL_FPGA_GPIO_H
+#define __EOSS3_HAL_FPGA_GPIO_H
+
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+
+#define xCUR_BOARD
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* FPGA July 28 release for REV01
+  Pin Name	              PAD Number
+SIN  (UART RXD)                 PAD[45]
+SOUT  (UART TXD)                PAD[44]
+I2C_SCL (LCD)            	PAD[6]
+I2C_SDA (LCD)          		PAD[7]
+GPIO_PIN[0]              	PAD[3]
+GPIO_PIN[1]              	PAD[11]
+GPIO_PIN[2]              	PAD[19]
+GPIO_PIN[3]              	PAD[43]
+GPIO_PIN[4]              	PAD[8]
+GPIO_PIN[5]              	PAD[41]
+GPIO_PIN[6]              	PAD[9]
+GPIO_PIN[7]              	PAD[13]
+GPIO_PIN[8]              	PAD[10]
+GPIO_PIN[9]              	PAD[17]
+GPIO_PIN[10]              	PAD[18]
+GPIO_PIN[11]              	PAD[23]
+GPIO_PIN[12]              	PAD[20]
+GPIO_PIN[13]              	PAD[21]
+GPIO_PIN[14]              	PAD[22]
+GPIO_PIN[15]              	PAD[16]
+GPIO_PIN[16]              	PAD[26]
+GPIO_PIN[17]              	PAD[27]
+GPIO_PIN[18]              	PAD[42]
+GPIO_PIN[19]              	PAD[12]
+GPIO_PIN[20]              	PAD[40]
+GPIO_PIN[21]              	PAD[2]
+I2C_SCL_SEN (HRM)               PAD[29]
+I2C_SDA_SEN (HRM)          	PAD[28]
+CLK_4MHZ_IN             	PAD[30]
+CLK_1MHZ_OUT            	PAD[31]
+
+*/
+                                  // REV00         //  REV01    
+#define FB_GPIO_0	0             // PAD3          //  PAD[3]    
+#define FB_GPIO_1	1             // PAD6          //  PAD[11]   
+#define FB_GPIO_2	2             // PAD8          //  PAD[19]   
+#define FB_GPIO_3	3             // PAD9          //  PAD[43]   
+#define FB_GPIO_4	4             // PAD10         //  PAD[8]    
+#define FB_GPIO_5	5             // PAD11         //  PAD[41]   
+#define FB_GPIO_6	6             // PAD12         //  PAD[9]    
+#define FB_GPIO_7	7             // PAD13         //  PAD[13]   
+#define FB_GPIO_8	8             // PAD23         //  PAD[10]   
+#define FB_GPIO_9	9             // PAD17         //  PAD[17]   
+#define FB_GPIO_10	10            // PAD18         //  PAD[18]    
+#define FB_GPIO_11	11            // PAD19         //  PAD[23]    
+#define FB_GPIO_12	12            // PAD20         //  PAD[20]    
+#define FB_GPIO_13	13            // PAD21         //  PAD[21]    
+#define FB_GPIO_14	14            // PAD22         //  PAD[22]    
+#define FB_GPIO_15	15            // PAD16         //  PAD[16]    
+#define FB_GPIO_16	16            // PAD26         //  PAD[26]    
+#define FB_GPIO_17	17            // PAD27         //  PAD[27]    
+#define FB_GPIO_18	18            // SFBIO[10]     //  PAD[42]    
+#define FB_GPIO_19	19            // SFBIO[11]     //  PAD[12]    
+#define FB_GPIO_20      20        // PAD7          //  PAD[40]    
+#define FB_GPIO_21      21        // PAD2          //  PAD[2]     
+
+
+
+/*! \fn HAL_StatusTypeDef HAL_FB_GPIO_Read(uint8_t ucGpioIndex, uint8_t *ucGpioVal)
+    \brief fpga GPIO read function to read pad status. Before using this function 
+      given pad needs to be initalized.
+    \param ucGpioIndex - GPIO index that needs to be read.
+    \param *ucGpioVal - GPIO status read, return value pointer.
+*/   
+HAL_StatusTypeDef HAL_FB_GPIO_Read(uint8_t ucGpioIndex, uint8_t *ucGpioVal);
+ 
+ /*! \fn HAL_StatusTypeDef HAL_FB_GPIO_Write(uint8_t ucGpioIndex, uint8_t ucGpioVal)
+    \brief fpga GPIO write function to read pad status. Before using this function 
+      given pad needs to be initalized.
+    \param ucGpioIndex - GPIO index that needs to be read.
+    \param ucGpioVal - GPIO status that nees to be written.
+*/
+HAL_StatusTypeDef HAL_FB_GPIO_Write(uint8_t ucGpioIndex, uint8_t ucGpioVal);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __EOSS3_HAL_FPGA_GPIO_H */

--- a/HAL/inc/eoss3_hal_fpga_sdma_api.h
+++ b/HAL/inc/eoss3_hal_fpga_sdma_api.h
@@ -1,0 +1,77 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_sdma_api.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_EOSS3_HAL_FPGA_SDMA_API_H_
+#define HAL_EOSS3_HAL_FPGA_SDMA_API_H_
+
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+
+/* Datasize unit of SDMA transfers. */
+typedef enum
+{
+  DATASIZE_BYTE  = 8,
+  DATASIZE_HWORD = 16,
+  DATASIZE_WORD  = 32,
+  DTASIZE_INVALID
+} DATA_SIZE;
+
+/* SDMA channel configuration to use in HAL_FSDMA_GetChannel API. */
+typedef struct __FSDMA_Channel_Config
+{
+  DATA_SIZE   data_size;
+  uint32_t    r_power;
+}ch_cfg_t;
+
+/* Initilazation of FPGA SDMA HAL driver. */
+HAL_StatusTypeDef HAL_FSDMA_Init(void);
+
+/*
+ * API to get a channel handle to make transfer and Receive data from FPGA IP.
+ *   On channel resource allocation, handle will be returned. Applciation should use
+ *   this handle for next transfer/Receive APIs.
+ * If transfer completes between FPGA and SRAM, callback will be triggered.
+ * If callback parameter is NULL, Transfer and receive APIs are synchronous.
+ */
+void* HAL_FSDMA_GetChannel(void (*pCallback)(void*), ch_cfg_t *cfg);
+
+/*
+ * API to release channel resource.
+ *
+ */
+HAL_StatusTypeDef HAL_FSDMA_ReleaseChannel(void *handle);
+
+/*
+ * Transfer data of length bytes from SRAM source to FPGA IP.
+ * Assuming, Destination in FPGA IP is fixed Fifo Data register
+ * length is transfer size in bytes.
+ */
+HAL_StatusTypeDef HAL_FSDMA_Send(void *handle, void *srcptr, uint32_t length);
+
+/*
+ * Transfer data of length bytes from FPGA IP to SRAM destination address.
+ * Assuming, Source in FPGA IP is fixed Fifo Data register.
+ * length is transfer size in bytes.
+ */
+HAL_StatusTypeDef HAL_FSDMA_Receive(void *handle, void *dstptr, uint32_t length);
+
+
+#endif //HAL_EOSS3_HAL_FPGA_SDMA_API_H_

--- a/HAL/inc/eoss3_hal_fpga_sdma_reg.h
+++ b/HAL/inc/eoss3_hal_fpga_sdma_reg.h
@@ -1,0 +1,46 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_sdma_reg.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef HAL_EOSS3_HAL_FPGA_SDMA_REG_H_
+#define HAL_EOSS3_HAL_FPGA_SDMA_REG_H_
+
+#define FB_FSDMA_BASE   (FPGA_PERIPH_BASE + 0x10000)
+#define FB_SDMA         ((FSDMA_TypeDef *) FB_FSDMA_BASE)
+
+#define FSDMA_CH0_DATA_REGISTER  (FB_FSDMA_BASE + 0x1000)
+#define FSDMA_CH1_DATA_REGISTER  (FB_FSDMA_BASE + 0x2000)
+#define FSDMA_CH2_DATA_REGISTER  (FB_FSDMA_BASE + 0x3000)
+#define FSDMA_CH3_DATA_REGISTER  (FB_FSDMA_BASE + 0x4000)
+
+/* FPGA SDMA register definitions. */
+typedef struct
+{
+  __IO uint32_t FSDMA_ENR;     /*0x0 */    //DMA Enable Register
+  __IO uint32_t FSDMA_SR;      /*0x4 */    // DMA status Register
+  __IO uint32_t FSDMA_INTEN;   /*0x8 */    //DMA Interrupt Enable Register
+
+} FSDMA_TypeDef;
+
+#define FSDMA_CHANNEL_EN(ch)       (0x1 << ch)   //DMA Channel Enable
+#define FSDMA_CHANNEL_INTR_CLR(ch) (0x1 << ch)   //DMA Interrupt Status [Read - Status, Write - clearing interrupt]
+#define FSDMA_CHANNEL_INTR_EN(ch)  (0x1 << ch)   //DMA Interrupt Enable at IP level [NVIC level enabling is seperate from this]
+#define FSDMA_CHANNEL_POS(ch)      (ch)          // Get Channel Position value
+
+#endif //HAL_EOSS3_HAL_FPGA_SDMA_REG_H_

--- a/HAL/inc/eoss3_hal_fpga_uart.h
+++ b/HAL/inc/eoss3_hal_fpga_uart.h
@@ -1,0 +1,154 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_fpga_uart.h
+ *    Purpose 	: This file contains API declaration for UART read/write
+ *         implmented in fpga 
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_FB_UART_H_
+#define __EOSS3_HAL_FB_UART_H_
+#include <stdint.h>
+#include <stddef.h>
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+#include "eoss3_hal_uart.h"
+
+
+//
+// Interrupt Enable Register
+//
+
+#define IER_ERXRDY      0x01
+#define IER_ETXRDY      0x02
+#define IER_ERLS        0x04
+#define IER_EMSC        0x08
+
+//
+// Interrupt Identification Register
+//
+
+#define IIR_IMASK       0x0F
+#define IIR_NOPEND      0x01
+#define IIR_MLSC        0x00
+#define IIR_TXRDY       0x02
+#define IIR_RXRDY       0x04
+#define IIR_RLS         0x06
+#define IIR_RXTOUT      0x0C
+#define IIR_FIFO_MASK   0xC0    // Set if FIFOs are enabled
+
+//
+// FIFO Control Register
+//
+
+#define FCR_ENABLE      0x01
+#define FCR_RCV_RST     0x02
+#define FCR_XMT_RST     0x04
+#define FCR_DMA_MODE    0x08
+#define FCR_TRIGGER_1   0x00
+#define FCR_TRIGGER_4   0x40
+#define FCR_TRIGGER_8   0x80
+#define FCR_TRIGGER_14  0xC0
+
+//
+// Line Control Register
+//
+
+#define LCR_DLAB        0x80
+#define LCR_SBREAK      0x40
+#define LCR_PZERO       0x30
+#define LCR_PONE        0x20
+#define LCR_PEVEN       0x10
+#define LCR_PODD        0x00
+#define LCR_PENAB       0x08
+#define LCR_STOPB       0x04
+#define LCR_8BITS       0x03
+#define LCR_7BITS       0x02
+#define LCR_6BITS       0x01
+#define LCR_5BITS       0x00
+
+//
+// Modem Control Register
+//
+
+
+#define MCR_FLOW        0x20
+#define MCR_LOOPBACK    0x10
+#define MCR_OUT2        0x08
+#define MCR_OUT1        0x04
+#define MCR_RTS         0x02
+#define MCR_DTR         0x01
+
+//
+// Line Status Register
+//
+
+#define LSR_RCV_FIFO    0x80
+#define LSR_THRE        0x40
+#define LSR_TXRDY       0x20
+#define LSR_BI          0x10
+#define LSR_FE          0x08
+#define LSR_PE          0x04
+#define LSR_OE          0x02
+#define LSR_RXRDY       0x01
+#define LSR_RCV_MASK    0x1F
+
+//
+// Modem Status Register
+//
+
+#define MSR_DCD         0x80
+#define MSR_RI          0x40
+#define MSR_DSR         0x20
+#define MSR_CTS         0x10
+#define MSR_DDCD        0x08
+#define MSR_TERI        0x04
+#define MSR_DDSR        0x02
+#define MSR_DCTS        0x01
+
+/*! \fn vvoid HAL_FB_UART_Init(UartHandler *ptrObj)
+ *  \brief Initialize UART implemented in FPGA
+ *
+ *  \param ptrObj       Pointer to UART handler structure
+ *  \return status
+ */
+//HAL_StatusTypeDef HAL_FB_UART_Init(UartHandler *pxObj);
+void HAL_FB_UART_Init(UartHandler *pxObj);
+
+/*! \fn void HAL_FB_UART_Stop(void)
+ *  \brief Stop pending RX/TX.
+ *
+ */
+void HAL_FB_UART_Stop(void);
+
+
+/*! \fn void HAL_FB_UART_Tx(int c)
+ *  \brief Send byte over UART.
+ *
+ *  \param c    Byte to transmit over UART
+ */
+void HAL_FB_UART_Tx(int c);
+
+/*! \fn int HAL_FB_UART_Rx(void)
+ *  \brief Send byte over UART implemented in FPGA.
+ *
+ *  \return Byte read from UART
+ */
+int HAL_FB_UART_Rx(void);
+
+int fb_uart_read(int uartid, ptrdiff_t buf, size_t len);
+
+#endif /* !__EOSS3_HAL_FB_UART_H_ */

--- a/HAL/inc/eoss3_hal_gpio.h
+++ b/HAL/inc/eoss3_hal_gpio.h
@@ -1,0 +1,135 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_gpio.h
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             read/write GPIO 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_GPIO_H
+#define __EOSS3_HAL_GPIO_H
+
+#include "eoss3_dev.h"
+#include "eoss3_hal_pad_config.h"
+
+#include "eoss3_hal_def.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/*! \def GPIO_0
+    \brief GPIO index 0.
+*/
+#define GPIO_0	0
+   
+/*! \def GPIO_1
+    \brief GPIO index 1.
+*/   
+#define GPIO_1	1
+   
+/*! \def GPIO_2
+    \brief GPIO index 3.
+*/   
+#define GPIO_2	2
+   
+/*! \def GPIO_3
+    \brief GPIO index 3.
+*/   
+#define GPIO_3	3
+   
+/*! \def GPIO_4
+    \brief GPIO index 4.
+*/   
+#define GPIO_4	4
+   
+/*! \def GPIO_5
+    \brief GPIO index 5.
+*/   
+#define GPIO_5	5
+   
+/*! \def GPIO_6
+    \brief GPIO index 6.
+*/   
+#define GPIO_6	6
+   
+/*! \def GPIO_7
+    \brief GPIO index 7.
+*/   
+#define GPIO_7	7
+
+#define PAD_COUNT	46
+
+#define S_INTR_SEL_BASE		((volatile uint32_t *)0x40004D3C)
+
+typedef enum
+{
+	LEVEL_TRIGGERED = 0,
+	EDGE_TRIGGERED = 1
+}GPIO_INTR_TYPE;
+
+typedef enum
+{
+	FALL_LOW = 0,
+	RISE_HIGH = 1
+}GPIO_POL_TYPE;
+
+/*!
+ * \brief GPIO Configuration Structure definition
+ */
+typedef struct __GPIOCfgTypeDef
+{
+	UINT8_t   ucGpioNum;
+	PadConfig *xPadConf;
+	GPIO_INTR_TYPE	intr_type;
+	GPIO_POL_TYPE	pol_type;	
+	
+}GPIOCfgTypeDef;
+
+
+/*! \fn HAL_GPIO_Read(uint8_t ucGpioIndex, uint8_t *ucGpioVal)
+    \brief GPIO read function to read pad status. Before using this function 
+      given pad needs to be initalized.
+    \param ucGpioIndex - GPIO index that needs to be read.
+    \param *ucGpioVal - GPIO status read, return value pointer.
+    \return None
+*/   
+void HAL_GPIO_Read(uint8_t ucGpioIndex, uint8_t *ucGpioVal);
+
+
+ /*! \fn HAL_GPIO_Write(uint8_t ucGpioIndex, uint8_t ucGpioVal)
+    \brief GPIO write function to write to pad . Before using this function 
+      given pad needs to be initalized.
+    \param ucGpioIndex - GPIO index that needs to be written.
+    \param ucGpioVal - GPIO status that needs to be written.
+    \return None
+*/
+void HAL_GPIO_Write(uint8_t ucGpioIndex, uint8_t ucGpioVal);
+
+ /*! \fn HAL_StatusTypeDef  HAL_GPIO_IntrCfg(GPIOCfgTypeDef *hGpioCfg)
+    \brief Function to write to configure pad as GPIO interrupt in INTR_CTRL and IO_MUX.
+    \param hGpioCfg - pointer to GPIO configuration structure.
+    \return gpio IRQ number
+*/
+int HAL_GPIO_IntrCfg(GPIOCfgTypeDef *hGpioCfg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __EOSS3_HAL_PADS_H */

--- a/HAL/inc/eoss3_hal_i2c.h
+++ b/HAL/inc/eoss3_hal_i2c.h
@@ -1,0 +1,173 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_i2c.h
+ *    Purpose 	: This file contains API declaration for I2C read/write
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_I2C_H_
+#define __EOSS3_HAL_I2C_H_
+#include <stdint.h>
+#include <stddef.h>
+#include "test_types.h"
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+
+   
+/* I2C internal states */
+typedef enum
+{
+  I2C_RESET=0,
+  I2C_READY,
+  I2C_BUSY,
+  I2C_TIMEOUT
+}I2C_State;
+
+/* I2C clock frequency */
+typedef enum
+{
+  I2C_100KHZ = 1,
+  I2C_200KHZ,
+  I2C_300Khz,
+  I2C_400KHZ,
+  I2C_INVALID
+}I2C_FREQ;
+   
+/* interrupt mode */
+typedef enum
+{
+  I2C_DISABLE = 0,
+  I2C_ENABLE
+} I2C_IntMode;
+
+#define  I2C_PRELO                                  0
+#define  I2C_PREHI                                  1
+#define  I2C_MCR                                    2
+#define  I2C_TXRX_DR                                3
+#define  I2C_CMD_SR                                 4
+  
+  
+/* Clock prescale macros */
+//Note: 12-14-2018. This is incorrect. Use the Table lookup computation 
+//#define HAL_I2C_CLK_PRESCALE(SYS_FREQ, I2C_FREQ)    (I2C_FREQ?(SYS_FREQ/(I2C_FREQ*5))-1:0)
+#define HAL_I2C_WRITE_PRESCALE(PRESCALE)            (I2C->I2C_PRELO = PRESCALE&0xFF); (I2C->I2C_PREHI = (PRESCALE >> 8)&0xFF)
+
+/* Control register macros */
+
+#define I2C_CR_EN_BIT                               7
+#define I2C_CR_IEN_BIT                              6
+
+#define HAL_I2C_ENABLE()                            (I2C->I2C_MCR |= 1<<I2C_CR_EN_BIT)
+#define HAL_I2C_DISABLE()                           (I2C->I2C_MCR &= ~(1<<I2C_CR_EN_BIT))
+
+#define HAL_I2C_INT_ENABLE()                        (I2C->I2C_MCR |= 1<<I2C_CR_IEN_BIT)
+#define HAL_I2C_INT_DISABLE()                       (I2C->I2C_MCR &= ~(1<<I2C_CR_IEN_BIT))
+
+/* Data register macros */
+#define HAL_I2C_WRITE_REQ(DEV_ADR)                  (I2C->I2C_TXRX_DR = (UINT8_t)((DEV_ADR<<1) & (~1)))
+#define HAL_I2C_READ_REQ(DEV_ADR)                   (I2C->I2C_TXRX_DR = (UINT8_t)((DEV_ADR<<1) | 1))  
+
+/* Command register macros */
+
+#define CMD_START_BIT                               0x80
+#define CMD_STOP_BIT                                0x40
+#define CMD_READ_SLAVE_BIT                          0x20
+#define CMD_WRITE_SLAVE_BIT                         0x10
+#define CMD_NACK_BIT                                 0x08
+#define CMD_IACK_BIT                                0x01
+  
+#define HAL_I2C_SET_CMD(CMD_VAL)                    (I2C->I2C_CMD_SR = (UINT8_t)CMD_VAL)
+
+/* Status register macros */
+
+#define SR_RXACK_BIT                                7
+#define SR_BUSY_BIT                                 6
+#define SR_AL_BIT                                   5
+#define SR_TIP_BIT                                  1
+#define SR_IF_BIT                                   0
+  
+#define HAL_I2C_IS_RXACK_SET()                      (I2C->I2C_CMD_SR & (1<<SR_RXACK_BIT))
+#define HAL_I2C_IS_BUSY_SET()                       (I2C->I2C_CMD_SR & (1<<SR_BUSY_BIT))
+#define HAL_I2C_IS_AL_SET()                         (I2C->I2C_CMD_SR & (1<<SR_AL_BIT))
+#define HAL_I2C_IS_TIP_SET()                        (I2C->I2C_CMD_SR & (1<<SR_TIP_BIT))
+#define HAL_I2C_IS_IF_SET()                         (I2C->I2C_CMD_SR & (1<<SR_IF_BIT))
+
+
+/*! \struct FIFO_IntConfig eoss3_hal_i2c.h "inc/eoss3_hal_i2c.h"
+ * 	\brief I2C clock and interrupt configuration structure.
+ */
+typedef struct
+{
+	I2C_FREQ     eI2CFreq;                       /*!< I2C Frequency */
+	I2C_IntMode  eI2CInt;                        /*!< Interrupt enable */
+	UINT8_t	     ucI2Cn;
+}I2C_Config;
+
+/*! \fn HAL_StatusTypeDef HAL_I2C0_Select(void)
+ *  \brief Select I2C0 device to use for all I2C init/read/write operation.
+ *
+ *  \return HAL_StatusTypeDef      status of device.
+ */
+HAL_StatusTypeDef HAL_I2C0_Select(void);
+
+/*! \fn HAL_StatusTypeDef HAL_I2C1_Select(void)
+ *  \brief Select I2C1 device to use for all I2C init/read/write operation.
+ *
+ *  \return HAL_StatusTypeDef      status of device.
+ */
+HAL_StatusTypeDef HAL_I2C1_Select(void);
+
+/*! \fn HAL_StatusTypeDef HAL_I2C_Init(I2C_Config xI2CConfig)
+ *  \brief Select I2C1 device to use for all I2C init/read/write operation.
+ *
+ *  \param xI2CConfig           I2C configuration structure
+ *  \return HAL_StatusTypeDef   status of device Init operation.
+ */
+HAL_StatusTypeDef HAL_I2C_Init(I2C_Config xI2CConfig);
+
+/*! \fn HAL_StatusTypeDef HAL_I2C_SetClockFreq(UINT32_t uiClkFreq)
+ *  \brief Set clock frequency for I2C device. It may not be exact frequency when set.
+ *
+ *  \param uiClkFreq            I2C clock frequency to set.
+ *  \return HAL_StatusTypeDef   status of frequency set operation.
+ */
+HAL_StatusTypeDef HAL_I2C_SetClockFreq(UINT32_t uiClkFreq);
+
+/*! \fn HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+ *  \brief Write data to I2C device.
+ *
+ *  \param ucDevAddress         I2C device address.
+ *  \param ucAddress            offset address in device to write.
+ *  \param pucDataBuf           pointer to data array to write.
+ *  \param uiLength             Length of data to write (in bytes)
+ *  \return HAL_StatusTypeDef   status of I2C write operation.
+ */
+HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength);
+
+/*! \fn HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+ *  \brief Read data from I2C device.
+ *
+ *  \param ucDevAddress         I2C device address.
+ *  \param ucAddress            offset address in device to read.
+ *  \param pucDataBuf           pointer to data array to read.
+ *  \param uiLength             Length of data to read (in bytes)
+ *  \return HAL_StatusTypeDef   status of I2C read operation.
+ */
+HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength);
+
+HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength);
+HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength);
+#endif /* !__EOSS3_HAL_I2C_H_ */

--- a/HAL/inc/eoss3_hal_i2s.h
+++ b/HAL/inc/eoss3_hal_i2s.h
@@ -1,0 +1,180 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_i2s.h
+ *    Purpose 	: This file contains API declaration for I2S Rx/Tx 
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_I2S_H_
+#define __EOSS3_HAL_I2S_H_
+#include <stdint.h>
+
+/**
+ * @brief return value definitions
+ */
+#define HAL_I2S_RET_VAL          (0x0)
+#define HAL_I2S_RET_VAL_ERROR    (0x20)
+
+#define HAL_I2S_SUCCESS          (HAL_I2S_RET_VAL + 0x0)
+
+#define HAL_I2S_ERROR            (HAL_I2S_RET_VAL_ERROR + 0x1)
+#define HAL_I2S_TX_ERROR         (HAL_I2S_RET_VAL_ERROR + 0x2)
+#define HAL_I2S_RX_ERROR         (HAL_I2S_RET_VAL_ERROR + 0x3)
+#define HAL_I2S_TIME_OUT_ERROR   (HAL_I2S_RET_VAL_ERROR + 0x4)
+#define HAL_I2S_BAD_PARAMETER    (HAL_I2S_RET_VAL_ERROR + 0x5)
+#define HAL_I2S_INVALID_STATE    (HAL_I2S_RET_VAL_ERROR + 0x6)
+
+
+/**
+ * @brief I2S Stereo/Mono selection.
+ */
+#define I2S_CHANNELS_STEREO     0x0     /* Stereo channel */
+#define I2S_CHANNELS_MONO       0x1     /* Mono channel */
+
+/**
+ * @brief I2S Mono Left/ Mono Right selection.
+ */
+#define I2S_CHANNEL_MONO_LEFT   0x0     /* Mono Left channel */
+#define I2S_CHANNEL_MONO_RIGHT  0x1     /* Mono Right channel */
+
+/**
+ * @brief I2S Master/Slave in use details
+ */
+#define I2S_MASTER_ASSP_RX      0x0     /* I2S master in use with Rx */
+#define I2S_SLAVE_ASSP_TX       0x1     /* I2S slave in use with Tx */
+#define I2S_SLAVE_FABRIC_RX     0x2     /* I2S Slave with Rx on Fabric */
+#define I2S_MASTER_SLAVE_MAX    0x3     /* Max number of i2s instances */
+
+
+/**
+ * @brief I2S driver structure
+ */
+typedef struct
+{
+    uint8_t sdma_used; 		/* SDMA used, if not will use normal mode of Tx/Rx */
+    uint8_t i2s_wd_clk;     /* I2S left /right sync clock */
+      
+
+    uint8_t ch_sel;    /* Channel select (Stereo/Mono) */
+    uint8_t mono_sel;     /* Mono Left/Right Selection */
+} I2S_Config_t;
+
+/**
+ * @brief HAL_I2S_Cb_Handler_t I2S driver call back. Callback gets called after completion of Tx/Rx.
+ *
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S.
+ *
+ * @param[in]  p_data_received Pointer to the buffer with received data,
+ *                             or NULL if the handler is for Tx only.
+ * @param[out] p_data_to_send  Pointer to the buffer with data sent
+ *                             ,or NULL if the handler is for Rx only.
+ * @param[in]  buffer_size  Buffer size in bytes, Length of data received and/or sent.
+ *                              This value is always equal to half the size of 
+ *                        the buffers set by the call ql_i2s_data_tx_rx_start function.
+ *                             Since it uses ping pong buffer mechanism.
+ *                             
+ */
+typedef void (* HAL_I2S_Cb_Handler_t)(uint8_t i2s_id_sel, uint32_t const * p_data_received,
+                                  uint32_t * p_data_to_send,
+                                  uint16_t   buffer_size);
+
+/**
+ * @brief HAL_I2S_Init Function for initializing the I2S driver.
+ *
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S. 
+ *
+ * @param[in] p_i2s_cfg Pointer to the structure with initial configuration.
+ *
+ * @param[in] handler  callback for getting a callback once done with Rx/Tx.
+ *
+ * @retval HAL_I2S_SUCCESS in case of success, HAL_I2S_ERROR in case of
+ *         failure.
+ */
+uint32_t HAL_I2S_Init (uint8_t i2s_id_sel, I2S_Config_t *p_i2s_cfg, HAL_I2S_Cb_Handler_t handler);
+
+/**
+ * @brief HAL_I2S_TX_RX_Buffer Function for starting the Tx/Rx over I2S
+ *
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S. 
+ *
+ * @param[in] p_rx_buffer  receive buffer in case of RX otherwise NULL
+ *
+ * @param[in] p_tx_buffer  transmit buffer in case of RX otherwise NULL
+ *
+ * @param[in] buffer_size  Tx/Rx buffer size in Bytes (ping pong buffer mechanism)
+ *
+ * @retval  HAL_I2S_SUCCESS in case of success, else other error value defined
+ *          above.
+ */
+uint32_t HAL_I2S_TX_RX_Buffer (uint8_t i2s_id_sel, uint32_t * p_rx_buffer,
+                               uint32_t * p_tx_buffer,
+                               uint16_t   buffer_size);
+/**
+ * @brief HAL_I2S_Stop Function for stopping the ongoing Rx/Tx
+ *
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S 
+ *
+ * @retval  HAL_I2S_SUCCESS on success else HAL_I2S_ERROR.
+ */
+uint32_t HAL_I2S_Stop (uint8_t i2s_id_sel);
+
+/**
+ * @brief HAL_I2S_Uninit Function to undo the init
+ *
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S 
+ *
+ * @retval  HAL_I2S_SUCCESS on success else HAL_I2S_ERROR.
+ */
+uint32_t HAL_I2S_Uninit(uint8_t i2s_id_sel);
+
+/**
+ * @brief function pointers declaration to register for each i2s driver
+ */
+typedef uint32_t (* i2s_init)(I2S_Config_t *p_i2s_cfg,
+                       HAL_I2S_Cb_Handler_t handler);
+
+typedef uint32_t (* i2s_buffer)(uint32_t * p_rx_buffer,
+                            uint32_t * p_tx_buffer,
+                            uint16_t   buffer_size);
+
+typedef void (* i2s_stop)(void);
+typedef void (* i2s_uninit)(void);
+
+/**
+ * @brief function pointers for each i2s driver
+ */
+typedef struct
+{
+    uint8_t i2s_state; /* to maintain state of each i2s */
+
+    i2s_init initfn;
+    i2s_buffer bufferfn;
+    i2s_stop stopfn;
+    i2s_uninit un_initfn;
+} I2S_Drv_t; 
+
+/**
+ * @brief HAL_I2S_register_driver i2s slave/master drivers should register
+ * their function using this function
+ * @param[in] i2s_id_sel I2S ID which is a identifier for the I2S
+ *
+ * @param[in] i2s_drv_fn function pointers to be passed here from i2s drivers
+ *
+ * @retval  HAL_I2S_SUCCESS on success else HAL_I2S_ERROR.
+ */
+   
+uint32_t HAL_I2S_Register_Driver(uint8_t i2s_id_sel, I2S_Drv_t i2s_drv_fn);
+#endif /* !__EOSS3_HAL_I2S_H_ */

--- a/HAL/inc/eoss3_hal_i2s_drv.h
+++ b/HAL/inc/eoss3_hal_i2s_drv.h
@@ -1,0 +1,42 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_i2s_drv.h
+ *    Purpose 	: This file contains some of the common API's
+ * or structures which need not be exposed to the i2s driver user 
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_I2S_DRV_H_
+#define __EOSS3_HAL_I2S_DRV_H_
+#include <stdint.h>
+
+/* Register function for Master Rx */
+uint32_t HAL_I2S_Master_Assp_Register(void);
+
+/* Register function for Slave Tx */
+uint32_t HAL_I2S_Slave_Assp_Register(void);
+
+/* Register function for Slave Rx */
+uint32_t HAL_I2S_Slave_FB_Register(void);
+/* I2S Slave Tx  SDMA 0 done handler*/
+void HAL_I2S_SLAVE_SDMA_Assp_Done(void) ;
+
+/* I2S Master Rx Block Done handler */
+void HAL_I2S_Master_Assp_BlkDone_Hndlr(void);
+
+/* I2S Master Rx Buffer Done handler */
+void HAL_I2S_Master_Assp_BufDone_Hndlr(void);
+#endif /* __EOSS3_HAL_I2S_DRV_H_ */

--- a/HAL/inc/eoss3_hal_leds.h
+++ b/HAL/inc/eoss3_hal_leds.h
@@ -1,0 +1,40 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_leds.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef _leds_h
+#define _leds_h
+
+void LedGreenOn(void);
+void LedGreenOff(void);
+
+void LedBlueOn(void);
+void LedBlueOff(void);
+
+void LedOrangeOn_AutoOff(void);
+void LedOrangeOn(void);
+void LedOrangeOff(void);
+
+void LedYellowOn(void);
+void LedYellowOff(void);
+void LedYellowBlink(void);
+
+void turnOnLeds(uint8_t on);
+
+#endif /* !_leds_h */

--- a/HAL/inc/eoss3_hal_pad_config.h
+++ b/HAL/inc/eoss3_hal_pad_config.h
@@ -1,0 +1,191 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_pad_config.h
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             configure pads 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_PAD_AF_H
+#define __EOSS3_HAL_PAD_AF_H
+
+#include "eoss3_hal_pads.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+ /*PAD configuration Register bits*/
+ 
+/*! \def PAD_CTRL_SRC_A0
+    \brief Control block that controls pad, It's M4 or other controller where 
+    connected device does not interfear.
+*/
+#define  PAD_CTRL_SRC_A0			((uint8_t)0x00)   /* Source is Firmware for GPIO */
+   
+/*! \def PAD_CTRL_SRC_OTHER
+    \brief Control block that controls pad eg I2C controller, FFE0.
+*/
+#define  PAD_CTRL_SRC_OTHER			((uint8_t)0x01)   /* Source is HW controller */
+
+/*! \def PAD_CTRL_SRC_FPGA
+    \brief FPGA block controls pad.
+*/
+#define  PAD_CTRL_SRC_FPGA		((uint8_t)0x02)   /* Source is FPGA */
+
+/*! \def PAD_MODE_OUTPUT_EN
+    \brief Pad mode set as an output.
+*/      
+#define  PAD_MODE_OUTPUT_EN			((uint8_t)0x02)
+   
+/*! \def PAD_MODE_INPUT_EN
+    \brief Pad mode set as an input.
+*/      
+#define  PAD_MODE_INPUT_EN			((uint8_t)0x01)
+
+/*! \def PAD_NOPULL
+    \brief Pad no pull.
+*/      
+#define  PAD_NOPULL        			((uint8_t)0x00)
+   
+/*! \def PAD_PULLUP
+    \brief Pad pull up.
+*/      
+#define  PAD_PULLUP        			((uint8_t)0x01)
+
+/*! \def PAD_PULLDOWN
+    \brief Pad pull down.
+*/      
+#define  PAD_PULLDOWN      			((uint8_t)0x02)
+
+/*! \def PAD_KEEPER
+    \brief Pad keeper.
+*/      
+#define  PAD_KEEPER      			((uint8_t)0x03)
+
+/*! \def PAD_DRV_STRENGHT_2MA
+    \brief Pad driving current 2mA.
+*/      
+#define  PAD_DRV_STRENGHT_2MA     	((uint8_t)0x00)
+
+/*! \def PAD_DRV_STRENGHT_4MA
+    \brief Pad driving current 4mA.
+*/      
+#define  PAD_DRV_STRENGHT_4MA     	((uint8_t)0x01)
+   
+/*! \def PAD_DRV_STRENGHT_8MA
+    \brief Pad driving current 8mA..
+*/      
+#define  PAD_DRV_STRENGHT_8MA     	((uint8_t)0x02)
+   
+/*! \def PAD_DRV_STRENGHT_12MA
+    \brief Pad driving current 12mA..
+*/      
+#define  PAD_DRV_STRENGHT_12MA     	((uint8_t)0x03)
+
+/*! \def PAD_SLEW_RATE_SLOW
+    \brief Pad slew rate slow half of actual frequency.
+*/   
+#define  PAD_SLEW_RATE_SLOW     	((uint8_t)0x00)	/* Slow (half frequency) */
+
+/*! \def PAD_SLEW_RATE_FAST
+    \brief Pad slew rate fast.
+*/      
+#define  PAD_SLEW_RATE_FAST     	((uint8_t)0x01)
+
+/*! \def PAD_SMT_TRIG_EN
+    \brief Schmitt trigger enable for given pad.
+*/      
+#define  PAD_SMT_TRIG_EN     		((uint8_t)0x01)
+   
+/*! \def PAD_SMT_TRIG_DIS
+    \brief Schmitt trigger disable for given pad.
+*/      
+#define  PAD_SMT_TRIG_DIS     		((uint8_t)0x00)
+
+   
+/*! \struct PadConfig
+ *  \brief Pad Configuration structure that is filled up by programmer to select 
+   pad function.
+ */
+ typedef struct
+ {
+	uint8_t ucPin;          /*!< Pad or Pin number starts from 0, Refer file eoss3_hal_pads.h macros PAD_0 to PAD_45*/
+
+	uint32_t ucFunc;        /*!< Pad function selection listed in eoss3_hal_pad.h for each pad, each pad function listed with PAD0_FUNC_XXX to PAD45_FUNC_XXX*/
+
+	uint8_t ucCtrl;         /*!< Pad controller A0 = Firmware; Other=M4 HW(Debugger, I2C) or FFE, FPGA */
+
+	uint8_t ucMode;         /*!< Pad Output or Input function, OEN or REN*/
+
+	uint8_t ucPull;         /*!< Pad Pull up config Z/up/down/keeper*/
+
+	uint8_t ucDrv;          /*!< Pad Current driving strenght*/
+
+	uint8_t ucSpeed;        /*!< Pad operating speed slow or fast*/
+
+	uint8_t ucSmtTrg;       /*!< Pad configure for Schmitt trigger*/
+
+ }PadConfig;
+
+ /// @cond INTERNAL_STRUCT
+ /*! \struct PadConfigReg
+ *  \brief Pad Configuration register bit field to write directly in Pad config 
+    register. This is for internal use, Programmer may not need to use it.
+ */
+ typedef struct
+ {
+	uint32_t bFunc:3;
+
+	uint32_t bCtrl:2;
+
+	uint32_t bOEn:1;
+
+	uint32_t bOPull:2;
+
+	uint32_t bODrv:2;
+
+	uint32_t bSpeed:1;
+
+	uint32_t bIEn:1;
+
+	uint32_t bSmtTrg:1;
+ }PadConfigReg;
+/// @endcond
+
+/*! \fn HAL_PAD_Config(PadConfig *pxPadInit)
+    \brief Pad config function to configure pad functionality. This function
+    need to be called with appropriate configuration before using it.
+
+    \param *pxPadInit - Pad config structure data filled for given pad.
+*/  
+void HAL_PAD_Config(PadConfig *pxPadInit);
+
+/*! \fn HAL_PAD_DeConfig(PadConfig *pxPadInit)
+    \brief Pad config function to deconfigure of pad functionality and put that 
+    pad in the default state.
+
+    \param *pxPadInit - Pad config structure data filled for given pad.
+*/
+void HAL_PAD_DeConfig(PadConfig *pxPadInit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __EOSS3_HAL_PAD_AF_H */

--- a/HAL/inc/eoss3_hal_pads.h
+++ b/HAL/inc/eoss3_hal_pads.h
@@ -1,0 +1,429 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_pads.h
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             configure pads 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_PADS_H
+#define __EOSS3_HAL_PADS_H
+
+#include "eoss3_dev.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/*Sensorhub3B Pads, BGA package */
+#define PAD_0                 ((uint8_t) 0)  /* Pin 0 */
+#define PAD_1                 ((uint8_t) 1)  /* Pin 1 */
+#define PAD_2                 ((uint8_t) 2)
+#define PAD_3                 ((uint8_t) 3)
+#define PAD_4                 ((uint8_t) 4)
+#define PAD_5                 ((uint8_t) 5)
+#define PAD_6                 ((uint8_t) 6)
+#define PAD_7                 ((uint8_t) 7)
+#define PAD_8                 ((uint8_t) 8)
+#define PAD_9                 ((uint8_t) 9)
+#define PAD_10                 ((uint8_t) 10)
+
+#define PAD_11                 ((uint8_t) 11)
+#define PAD_12                 ((uint8_t) 12)
+#define PAD_13                 ((uint8_t) 13)
+#define PAD_14                 ((uint8_t) 14)
+#define PAD_15                 ((uint8_t) 15)
+#define PAD_16                 ((uint8_t) 16)
+#define PAD_17                 ((uint8_t) 17)
+#define PAD_18                 ((uint8_t) 18)
+#define PAD_19                 ((uint8_t) 19)
+#define PAD_20                 ((uint8_t) 20)
+
+#define PAD_21                 ((uint8_t) 21)
+#define PAD_22                 ((uint8_t) 22)
+#define PAD_23                 ((uint8_t) 23)
+#define PAD_24                 ((uint8_t) 24)
+#define PAD_25                 ((uint8_t) 25)
+#define PAD_26                 ((uint8_t) 26)
+#define PAD_27                 ((uint8_t) 27)
+#define PAD_28                 ((uint8_t) 28)
+#define PAD_29                 ((uint8_t) 29)
+#define PAD_30                 ((uint8_t) 30)
+
+#define PAD_31                 ((uint8_t) 31)
+#define PAD_32                 ((uint8_t) 32)
+#define PAD_33                 ((uint8_t) 33)
+#define PAD_34                 ((uint8_t) 34)
+#define PAD_35                 ((uint8_t) 35)
+#define PAD_36                 ((uint8_t) 36)
+#define PAD_37                 ((uint8_t) 37)
+#define PAD_38                 ((uint8_t) 38)
+#define PAD_39                 ((uint8_t) 39)
+#define PAD_40                 ((uint8_t) 40)
+
+#define PAD_41                 ((uint8_t) 41)
+#define PAD_42                 ((uint8_t) 42)
+#define PAD_43                 ((uint8_t) 43)
+#define PAD_44                 ((uint8_t) 44)
+#define PAD_45                 ((uint8_t) 45)
+
+/// @endcond
+   
+/// @cond EXTENDED_REGS_OFFSET
+/*Extended Configuration registers offset*/
+#define SDA0_SEL 	0x100
+#define SDA1_SEL	0x104
+#define	SDA2_SEL	0x108
+#define SCL0_SEL	0x10C
+#define SCL1_SEL	0x110
+#define SCL2_SEL	0x114
+#define	SPIs_CLK_SEL	0x118
+#define SPIs_SSn_SEL	0x11C
+#define SPIs_MOSI_SEL	0x120
+#define SPIm_MISO_SEL	0x124
+#define PDM_DATA_SEL	0x128
+#define I2S_DATA_SEL	0x12C
+#define UART_RXD_SEL	0x134
+#define IRDA_SIRIN_SEL	0x138
+#define S_INTR_0_SEL	0x13C
+#define S_INTR_1_SEL	0x140
+#define S_INTR_2_SEL	0x144
+#define S_INTR_3_SEL	0x148
+#define S_INTR_4_SEL	0x14C
+#define S_INTR_5_SEL	0x150
+#define S_INTR_6_SEL	0x154
+#define S_INTR_7_SEL	0x158
+#define nUARTCTS_SEL	0x15C
+#define IO_REG_SEL		0x160
+#define SW_CLK_SEL		0x170
+#define SW_IO_SEL		0x174
+#define FBIO_SEL_1		0x180
+#define	FBIO_SEL_2		0x184
+#define SPI_SENSOR_MISO_SEL	0x190
+#define SPI_SENSOR_MOSI_SEL	0x194
+#define I2S_WD_CLKIN_SEL	0x1A0
+#define I2S_CLKIN_SEL	0x1A4
+#define PDM_STAT_IN_SEL	0x1A8
+#define PDM_CLKIN_SEL	0x1AC3
+/*Ext registers End*/
+
+#define EXT_REG_OFFSET_SHIFT 	20
+#define EXT_REG_OFFSET_BASE	SDA0_SEL
+
+/// @endcond
+  
+ /*Pads Functions, INPUT functions configuration does not need any value
+  * so it has been taken as virtual function ID eg. sensor interrupt=0x8*/
+
+/// @cond PAD_CONFIG_ALTERNATE_FUNCTIONS
+#define PAD0_FUNC_SEL_SCL_0                         ((uint32_t) (0x00  | (SCL0_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD0_FUNC_SEL_FBIO_0                        ((uint32_t) (0x01  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD0_FUNC_SEL_RESERVE2                      ((uint32_t) (0x02))
+#define PAD0_FUNC_SEL_RESERVE3                      ((uint32_t) (0x03))
+
+#define PAD1_FUNC_SEL_SDA_0                         ((uint32_t) (0x00  | (SDA0_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD1_FUNC_SEL_FBIO_1                        ((uint32_t) (0x01  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD2_FUNC_SEL_FBIO_2                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD2_FUNC_SEL_SPI_SENSOR_SSn_2              ((uint32_t) (0x01))
+#define PAD2_FUNC_SEL_DEBUG_MON_0					((uint32_t) (0x02))
+#define PAD2_FUNC_SEL_BATT_MON						((uint32_t) (0x03))
+#define PAD2_FUNC_SEL_SENS_INT_1					((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+//#define PAD3_FUNC_SEL_S_INTR_0					((uint32_t) (0x00)) /*old AP_INTR , FIXME: Input line  Intr*/
+#define PAD3_FUNC_SEL_FBIO_3                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD3_FUNC_SEL_SENS_INT_0					((uint32_t) (0x00  | (S_INTR_0_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD4_FUNC_SEL_FBIO_4                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD4_FUNC_SEL_SPI_SENSOR_SSn_3              ((uint32_t) (0x01))
+#define PAD4_FUNC_SEL_DEBUG_MON_1                   ((uint32_t) (0x02))
+#define PAD4_FUNC_SEL_SDA_1_DPU                     ((uint32_t) (0x03))
+#define PAD4_FUNC_SEL_SENS_INT_2					((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD5_FUNC_SEL_FBIO_5                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD5_FUNC_SEL_SPI_SENSOR_SSn_4              ((uint32_t) (0x01))
+#define PAD5_FUNC_SEL_DEBUG_MON_2                   ((uint32_t) (0x02))
+#define PAD5_FUNC_SEL_SDA_0_DPU                     ((uint32_t) (0x03))
+#define PAD5_FUNC_SEL_SENS_INT_3					((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD6_FUNC_SEL_FBIO_6                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD6_FUNC_SPI_SENSOR_MOSI                   ((uint32_t) (0x01  | (SPI_SENSOR_MOSI_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD6_FUNC_SEL_DEBUG_MON_3                   ((uint32_t) (0x02))
+#define PAD6_FUNC_SEL_GPIO_0                        ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+//#define PAD6_FUNC_SEL_FCLK                        ((uint32_t) (0x0)) Fixme:Not used
+#define PAD6_FUNC_SEL_IRDA_SIRIN                    ((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD6_FUNC_SEL_SENS_INT_1                    ((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD7_FUNC_SEL_FBIO_7                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD7_FUNC_SPI_SENSOR_SSN5                   ((uint32_t) (0x01))
+#define PAD7_FUNC_SEL_DEBUG_MON_4                   ((uint32_t) (0x02))
+#define PAD7_FUNC_SEL_SWV                           ((uint32_t) (0x03))
+//#define PAD7_FUNC_SEL_SENS_INT_5                    ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD7_FUNC_SEL_SENS_INT_4                   ((uint32_t) (0x00  | (S_INTR_4_SEL << EXT_REG_OFFSET_SHIFT)))
+   
+#define PAD8_FUNC_SEL_FBIO_8                       	((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD8_FUNC_PDM_CKO                        	((uint32_t) (0x01))
+#define PAD8_FUNC_I2S_CKO                      		((uint32_t) (0x02))
+#define PAD8_FUNC_IRDA_SIROUT                       ((uint32_t) (0x03))
+#define PAD8_FUNC_SEL_SPI_SENSOR_MISO				((uint32_t) (0x00  | (SPI_SENSOR_MISO_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD8_FUNC_SEL_SENS_INT_2                    ((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD9_FUNC_SEL_FBIO_9                        ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD9_FUNC_SEL_SPI_SENSOR_SSn_1              ((uint32_t) (0x01))
+#define PAD9_FUNC_SEL_I2S_WD_CKO                    ((uint32_t) (0x02))
+#define PAD9_FUNC_SEL_GPIO_1                        ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD9_FUNC_SEL_PDM_STAT_IN                   ((uint32_t) (0x00  | (PDM_STAT_IN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD9_FUNC_SEL_SENS_INT_3                    ((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD10_FUNC_SEL_FBIO_10                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD10_FUNC_SEL_SPI_SENSOR_CLK               ((uint32_t) (0x01))
+#define PAD10_FUNC_SEL_RESERVE                     	((uint32_t) (0x02))
+#define PAD10_FUNC_SEL_SWV                        	((uint32_t) (0x03))
+#define PAD10_FUNC_SEL_I2S_DIN						((uint32_t) (0x00  | (I2S_DATA_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD10_FUNC_SEL_PDM_DIN						((uint32_t) (0x00  | (PDM_DATA_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD10_FUNC_SEL_SENS_INT_4                   ((uint32_t) (0x00  | (S_INTR_4_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD11_FUNC_SEL_FBIO_11                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD11_FUNC_SEL_SPI_SENSOR_SSn_6             ((uint32_t) (0x01))
+#define PAD11_FUNC_SEL_DEBUG_MON_5                  ((uint32_t) (0x02))
+#define PAD11_FUNC_SEL_GPIO_2                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD11_FUNC_SEL_SENS_INT_5                   ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD12_FUNC_SEL_FBIO_12                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD12_FUNC_SEL_SPI_SENSOR_SSn_7             ((uint32_t) (0x01))
+#define PAD12_FUNC_SEL_DEBUG_MON_6                  ((uint32_t) (0x02))
+#define PAD12_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x03))
+#define PAD12_FUNC_SEL_SENS_INT_6                   ((uint32_t) (0x00  | (S_INTR_6_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD13_FUNC_SEL_FBIO_13                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD13_FUNC_SEL_SPI_SENSOR_SSn_8             ((uint32_t) (0x01))
+#define PAD13_FUNC_SEL_DEBUG_MON_7                  ((uint32_t) (0x02))
+#define PAD13_FUNC_SEL_SWV                          ((uint32_t) (0x03))
+#define PAD13_FUNC_SEL_SENS_INT_7                   ((uint32_t) (0x00  | (S_INTR_7_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD14_FUNC_SEL_FBIO_14                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD14_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x01))
+#define PAD14_FUNC_SEL_SCL_1                        ((uint32_t) (0x02  | (SCL1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD14_FUNC_SEL_GPIO_3                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD14_FUNC_SEL_SW_DP_CLK                    ((uint32_t) (0x00  | (SW_CLK_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD14_FUNC_SEL_UART_RXD                     ((uint32_t) (0x00  | (UART_RXD_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD14_FUNC_SEL_SENS_INT_5                   ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD15_FUNC_SEL_SW_DP_IO                     ((uint32_t) (0x00))
+#define PAD15_FUNC_SEL_FBIO_15                      ((uint32_t) (0x01  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD15_FUNC_SEL_SDA_1                        ((uint32_t) (0x02  | (SDA1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD15_FUNC_SEL_UART_TXD                     ((uint32_t) (0x03))
+#define PAD15_FUNC_SEL_DEBUG_MON_8                  ((uint32_t) (0x03))
+#define PAD15_FUNC_SEL_IRDA_SIRIN                   ((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD15_FUNC_SEL_SENS_INT_6                   ((uint32_t) (0x00  | (S_INTR_6_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD16_FUNC_SEL_FBIO_16                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD16_FUNC_SEL_SPIs_CLK                     ((uint32_t) (0x00  | (SPIs_CLK_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD16_FUNC_SEL_UART_RXD                     ((uint32_t) (0x00  | (UART_RXD_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD17_FUNC_SEL_SPIs_MISO                    ((uint32_t) (0x00))
+#define PAD17_FUNC_SEL_FBIO_17                      ((uint32_t) (0x01  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD17_FUNC_SEL_nUARTCTS                     ((uint32_t) (0x00  | (nUARTCTS_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD18_FUNC_SEL_FBIO_18                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD18_FUNC_SEL_SWV		                    ((uint32_t) (0x01))
+#define PAD18_FUNC_SEL_DEBUG_MON_0                  ((uint32_t) (0x02))
+#define PAD18_FUNC_SEL_GPIO_4                     	((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD18_FUNC_SEL_SENS_INT_1                   ((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD19_FUNC_SEL_FBIO_19                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD19_FUNC_SEL_UART_TXD                     ((uint32_t) (0x02))
+#define PAD19_FUNC_SEL_SPIs_MOSI                    ((uint32_t) (0x00  | (SPIs_MOSI_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD20_FUNC_SEL_FBIO_20                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD20_FUNC_SEL_UART_TXD                     ((uint32_t) (0x01))
+#define PAD20_FUNC_SEL_SPIs_SSn                      ((uint32_t) (0x00  | (SPIs_SSn_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD21_FUNC_SEL_FBIO_21                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD21_FUNC_SEL_nUARTRTS                     ((uint32_t) (0x01))
+#define PAD21_FUNC_SEL_DEBUG_MON_1                  ((uint32_t) (0x02))
+#define PAD21_FUNC_SEL_GPIO_5                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD21_FUNC_SEL_IRDA_SIRIN                   ((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD21_FUNC_SEL_SENS_INT_2                   ((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD22_FUNC_SEL_FBIO_22                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD22_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x01))
+#define PAD22_FUNC_SEL_DEBUG_MON_2                  ((uint32_t) (0x02))
+#define PAD22_FUNC_SEL_GPIO_6                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD22_FUNC_SEL_nUARTCTS                     ((uint32_t) (0x00  | (nUARTCTS_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD22_FUNC_SEL_SENS_INT_3                   ((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD23_FUNC_SEL_FBIO_23                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD23_FUNC_SEL_SPIm_SSn2                    ((uint32_t) (0x01))
+#define PAD23_FUNC_SEL_SWV                     		((uint32_t) (0x02))
+#define PAD23_FUNC_SEL_GPIO_7                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD23_FUNC_SEL_AP_I2S_WD_CLK_IN             ((uint32_t) (0x00  | (I2S_WD_CLKIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD23_FUNC_SEL_SENS_INT_7		            ((uint32_t) (0x00  | (S_INTR_7_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD24_FUNC_SEL_FBIO_24                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD24_FUNC_SEL_AP_I2S_DOUT                  ((uint32_t) (0x01))
+#define PAD24_FUNC_SEL_UART_TXD                     ((uint32_t) (0x02))
+#define PAD24_FUNC_SEL_GPIO_0                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD24_FUNC_SEL_IRDA_SIRIN                   ((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD24_FUNC_SEL_SENS_INT_1		            ((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD25_FUNC_SEL_FBIO_25                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD25_FUNC_SEL_SPIm_SSN3                    ((uint32_t) (0x01))
+#define PAD25_FUNC_SEL_SWV                          ((uint32_t) (0x02))
+#define PAD25_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x03))
+#define PAD25_FUNC_SEL_UART_RXD                     ((uint32_t) (0x00  | (UART_RXD_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD25_FUNC_SEL_SENS_INT_2		            ((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD26_FUNC_SEL_FBIO_26                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD26_FUNC_SEL_SPI_SENSOR_SSn_4             ((uint32_t) (0x01))
+#define PAD26_FUNC_SEL_DEBUG_MON_3                  ((uint32_t) (0x02))
+#define PAD26_FUNC_SEL_GPIO_1                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD26_FUNC_SEL_SENS_INT_4		            ((uint32_t) (0x00  | (S_INTR_4_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD27_FUNC_SEL_FBIO_27                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD27_FUNC_SEL_SPI_SENSOR_SSn_5             ((uint32_t) (0x01))
+#define PAD27_FUNC_SEL_DEBUG_MON_4                  ((uint32_t) (0x02))
+#define PAD27_FUNC_SEL_SPIm_SSn2                    ((uint32_t) (0x03))
+#define PAD27_FUNC_SEL_SPIm_SSN2                    (PAD27_FUNC_SEL_SPIm_SSn_2) //deprecated
+#define PAD27_FUNC_SEL_SENS_INT_5		            ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD28_FUNC_SEL_FBIO_28                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_SPI_SENSOR_MOSI              ((uint32_t) (0x01  | (SPI_SENSOR_MOSI_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_DEBUG_MON_5                  ((uint32_t) (0x02))
+#define PAD28_FUNC_SEL_GPIO_2                   	((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_I2S_DIN             			((uint32_t) (0x00  | (I2S_DATA_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_PDM_DIN             			((uint32_t) (0x00  | (PDM_DATA_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_IRDA_SIRIN             		((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD28_FUNC_SEL_SENS_INT_3		            ((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD29_FUNC_SEL_FBIO_29                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD29_FUNC_SEL_PDM_CKO                    	((uint32_t) (0x01))
+#define PAD29_FUNC_SEL_I2S_CKO                     	((uint32_t) (0x02))
+#define PAD29_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x03))
+#define PAD29_FUNC_SEL_SPI_SENSOR_MISO             	((uint32_t) (0x00  | (SPI_SENSOR_MISO_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD29_FUNC_SEL_SENS_INT_4		            ((uint32_t) (0x00  | (S_INTR_4_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD30_FUNC_SEL_FBIO_30                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD30_FUNC_SEL_SPI_SENSOR_SSn_1             ((uint32_t) (0x01))
+#define PAD30_FUNC_SEL_I2S_WD_CKO                   ((uint32_t) (0x02))
+#define PAD30_FUNC_SEL_GPIO_3                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD30_FUNC_SEL_PDM_STAT_IN             		((uint32_t) (0x00  | (PDM_STAT_IN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD30_FUNC_SEL_SENS_INT_5		            ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD31_FUNC_SEL_FBIO_31                      ((uint32_t) (0x00  | (FBIO_SEL_1 << EXT_REG_OFFSET_SHIFT)))
+#define PAD31_FUNC_SEL_SPI_SENSOR_CLK               ((uint32_t) (0x01))
+#define PAD31_FUNC_SEL_RESERVE                      ((uint32_t) (0x02))
+#define PAD31_FUNC_SEL_GPIO_4                     	((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD31_FUNC_SEL_AP_I2S_CLK_IN             	((uint32_t) (0x00  | (I2S_CLKIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD31_FUNC_SEL_SENS_INT_6		            ((uint32_t) (0x00  | (S_INTR_6_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD32_FUNC_SEL_FBIO_32                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD32_FUNC_SEL_SPI_SENSOR_SSn_5             ((uint32_t) (0x01))
+#define PAD32_FUNC_SEL_DEBUG_MON_6                  ((uint32_t) (0x02))
+#define PAD32_FUNC_SEL_SDA_1                        ((uint32_t) (0x03  | (SDA1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD32_FUNC_SEL_SENS_INT_6		            ((uint32_t) (0x00  | (S_INTR_6_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD33_FUNC_SEL_FBIO_33                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD33_FUNC_SEL_SPI_SENSOR_SSn_6             ((uint32_t) (0x01))
+#define PAD33_FUNC_SEL_DEBUG_MON_7                  ((uint32_t) (0x02))
+#define PAD33_FUNC_SEL_SCL_1                     	((uint32_t) (0x03  | (SCL1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD33_FUNC_SEL_SENS_INT_7		            ((uint32_t) (0x00  | (S_INTR_7_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD34_FUNC_SEL_SPIm_CLK                  	((uint32_t) (0x00))
+#define PAD34_FUNC_SEL_FBIO_34                      ((uint32_t) (0x01  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD34_FUNC_SEL_AP_PDM_STAT_O                ((uint32_t) (0x02  | (PDM_STAT_IN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD34_FUNC_SEL_DEBUG_MON_0                  ((uint32_t) (0x03))
+#define PAD34_FUNC_SEL_SENS_INT_7		            ((uint32_t) (0x00  | (S_INTR_7_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD35_FUNC_SEL_FBIO_35                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD35_FUNC_SEL_SPIm_SSn3                    ((uint32_t) (0x01))
+#define PAD35_FUNC_SEL_SPIm_SSN3                    ((uint32_t) (0x01)) // Deprecated
+#define PAD35_FUNC_SEL_SPI_SENSOR_SSn_7             ((uint32_t) (0x02))
+#define PAD35_FUNC_SEL_DEBUG_MON_1                  ((uint32_t) (0x03))
+#define PAD36_FUNC_SEL_SENS_INT_1		            ((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD36_FUNC_SEL_FBIO_36                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD36_FUNC_SEL_SWV                        	((uint32_t) (0x01))
+#define PAD36_FUNC_SEL_SPI_SENSOR_SSn_2             ((uint32_t) (0x02))
+#define PAD36_FUNC_SEL_GPIO_5                  		((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD36_FUNC_SEL_SPIm_MISO                  	((uint32_t) (0x00  | (SPIm_MISO_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD36_FUNC_SEL_SENS_INT_1		            ((uint32_t) (0x00  | (S_INTR_1_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD37_FUNC_SEL_FBIO_37                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD37_FUNC_SEL_SDA_2_DPU                    ((uint32_t) (0x01))
+#define PAD37_FUNC_SEL_SPI_SENSOR_SSn_8             ((uint32_t) (0x02))
+#define PAD37_FUNC_SEL_DEBUG_MON_2                  ((uint32_t) (0x03))
+#define PAD37_FUNC_SEL_SENS_INT_2		            ((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD38_FUNC_SEL_SPIm_MOSI                  	((uint32_t) (0x00))
+#define PAD38_FUNC_SEL_FBIO_38                      ((uint32_t) (0x01  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD38_FUNC_SEL_DEBUG_MON_3                  ((uint32_t) (0x02))
+#define PAD38_FUNC_SEL_GPIO_6                       ((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD38_FUNC_SEL_AP_PDM_CKO_IN             	((uint32_t) (0x00))
+#define PAD38_FUNC_SEL_SENS_INT_2		            ((uint32_t) (0x00  | (S_INTR_2_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD39_FUNC_SEL_SPIm_SSn1                  	((uint32_t) (0x00))
+#define PAD39_FUNC_SEL_FBIO_39                      ((uint32_t) (0x01  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD39_FUNC_SEL_AP_PDM_IO                    ((uint32_t) (0x02))
+#define PAD39_FUNC_SEL_DEBUG_MON_4                  ((uint32_t) (0x03))
+#define PAD39_FUNC_SEL_SENS_INT_3		            ((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD40_FUNC_SEL_FBIO_40                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD40_FUNC_SEL_SCL_2                        ((uint32_t) (0x01  | (SCL2_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD40_FUNC_SEL_DEBUG_MON_5                  ((uint32_t) (0x02))
+#define PAD40_FUNC_SEL_RESERVED                     ((uint32_t) (0x03))
+#define PAD40_FUNC_SEL_IRDA_SIRIN             		((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD40_FUNC_SEL_SENS_INT_3		            ((uint32_t) (0x00  | (S_INTR_3_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD41_FUNC_SEL_FBIO_41                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD41_FUNC_SEL_SDA_2                        ((uint32_t) (0x01  | (SDA2_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD41_FUNC_SEL_DEBUG_MON_6                  ((uint32_t) (0x02))
+#define PAD41_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x03))
+#define PAD41_FUNC_SEL_SENS_INT_6		            ((uint32_t) (0x00  | (S_INTR_6_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD42_FUNC_SEL_FBIO_42                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD42_FUNC_SEL_SWV                        	((uint32_t) (0x01))
+#define PAD42_FUNC_SEL_DEBUG_MON_7                  ((uint32_t) (0x02))
+#define PAD42_FUNC_SEL_SDA_1_DPU                    ((uint32_t) (0x03))
+#define PAD42_FUNC_SEL_SENS_INT_7		            ((uint32_t) (0x00  | (S_INTR_7_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD43_FUNC_SEL_AP_INTR                  	((uint32_t) (0x00))
+#define PAD43_FUNC_SEL_FBIO_43                      ((uint32_t) (0x01  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD44_FUNC_SEL_SW_DP_IO                  	((uint32_t) (0x00))
+#define PAD44_FUNC_SEL_FBIO_44                      ((uint32_t) (0x01  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD44_FUNC_SEL_SDA_1                  		((uint32_t) (0x02  | (SDA1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD44_FUNC_SEL_UART_TXD                  	((uint32_t) (0x03))
+#define PAD44_FUNC_SEL_IRDA_SIRIN             		((uint32_t) (0x00  | (IRDA_SIRIN_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD44_FUNC_SEL_SENS_INT_4		            ((uint32_t) (0x00  | (S_INTR_4_SEL << EXT_REG_OFFSET_SHIFT)))
+
+#define PAD45_FUNC_SEL_FBIO_45                      ((uint32_t) (0x00  | (FBIO_SEL_2 << EXT_REG_OFFSET_SHIFT)))
+#define PAD45_FUNC_SEL_IRDA_SIROUT                  ((uint32_t) (0x01))
+#define PAD45_FUNC_SEL_SCL_1	                  	((uint32_t) (0x02  | (SCL1_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD45_FUNC_SEL_GPIO_7                  		((uint32_t) (0x03  | (IO_REG_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD45_FUNC_SEL_SW_DP_CLK             		((uint32_t) (0x00))
+#define PAD45_FUNC_SEL_UART_RXD             		((uint32_t) (0x00  | (UART_RXD_SEL << EXT_REG_OFFSET_SHIFT)))
+#define PAD45_FUNC_SEL_SENS_INT_5		            ((uint32_t) (0x00  | (S_INTR_5_SEL << EXT_REG_OFFSET_SHIFT)))
+
+/// @endcond
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __EOSS3_HAL_PADS_H */

--- a/HAL/inc/eoss3_hal_pkfb.h
+++ b/HAL/inc/eoss3_hal_pkfb.h
@@ -1,0 +1,434 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_pkfb.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_PKFB_H_
+#define __EOSS3_HAL_PKFB_H_
+
+#include "eoss3_dev.h"
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+
+ /******************************************************************************
+  * 						    Packet FIFO                                    *
+  ******************************************************************************/
+/*!	\enum FIFO_Type
+	\brief FIFO types available
+*/
+typedef enum
+{
+    FIFO0 = 0,
+    FIFO1,
+    FIFO2,
+    FIFO8K,
+    FIFO_INVALID = -1
+}FIFO_Type;
+
+/*!	\enum FIFO_SrcType
+	\brief FIFO sources that can push data to FIFO
+*/
+typedef enum
+{
+	FIFO_SRC_M4 = 0,
+	FIFO_SRC_FFE0,
+	FIFO_SRC_FFE1,
+	FIFO_SRC_INVALID = -1
+} FIFO_SrcType;
+
+/*!	\enum FIFO_DestType
+	\brief FIFO destinations that can pop data from FIFO
+*/
+typedef enum
+{
+	FIFO_DEST_M4 = 0,
+	FIFO_DEST_AP,
+	FIFO_DEST_INVALID = -1,
+} FIFO_DestType;
+
+/*!	\enum FIFO_PushIntType
+	\brief FIFO interrupt configuration for Push side
+*/
+typedef enum
+{
+	FIFO_PUSH_INT_OVERFLOW = 0x1,
+	FIFO_PUSH_INT_THRESHOLD = 0x2,
+	FIFO_PUSH_INT_SRAM_SLEEP = 0x4,
+	FIFO_PUSH_INT_INVALID = -1
+}FIFO_PushIntType;
+
+/*!	\enum FIFO_PopIntType
+	\brief FIFO interrupt configuration for Pop side
+*/typedef enum
+{
+	FIFO_POP_INT_UNDERFLOW = 0x1,
+	FIFO_POP_INT_THRESHOLD = 0x2,
+	FIFO_POP_INT_SRAM_SLEEP = 0x4,
+	FIFO_POP_INT_INVALID = -1
+}FIFO_PopIntType;
+
+
+/*! \def FIFO_WORD_WIDTH
+    \brief A macro to define FIFO0, FIFO1 and FIFO2 WORD Width.
+*/
+#define FIFO_WORD_WIDTH				   4 		//4 Bytes or 32 bits
+
+/*! \def FIFO8X_WORD_WIDTH
+    \brief A macro to define 8K FIFO WORD Width.
+*/
+#define FIFO8X_WORD_WIDTH			   4 		//4 Bytes or 32 bits
+
+/*! \def FIFO0_SZ
+    \brief A macro to define FIFO 0 size in words.
+*/
+#define FIFO0_SZ                      (256)
+
+/*! \def FIFO1_SZ
+    \brief A macro to define FIFO 1 size in words.
+*/
+#define FIFO1_SZ                      (128)
+
+/*! \def FIFO2_SZ
+    \brief A macro to define FIFO 2 size in words.
+*/
+#define FIFO2_SZ                      (128)
+
+/*! \def FIFO8K_SZ
+    \brief A macro to define FIFO 8K size in words.
+*/
+#define FIFO8K_SZ                     (8*1024)
+
+///@cond PKFB_MACROS
+/******************************************************************************
+ *                                   PKFB                                     *
+ ******************************************************************************/
+/* FIFO interrupt configuration bit definition */
+#define	FIFO_NO_INT                   (0x00)
+#define	FIFO_PUSH_OVERFLOW_INT        (0x01)
+#define	FIFO_PUSH_THRESH_INT          (0x02)
+#define	FIFO_PUSH_SLEEP_INT           (0x04)
+#define	FIFO_POP_UNDERFLOW_INT        (0x08)
+#define	FIFO_POP_THRESH_INT           (0x10)
+#define	FIFO_POP_SLEEP_INT            (0x20)
+
+/* Macros and bit definition for FIFO control register */
+
+#define FIFO_CTRL_ENABLE                               ((uint32_t) (0x00000000))
+#define FIFO_CTRL_PUSH_MUX                             ((uint32_t) (0x00000001))
+#define FIFO_CTRL_POP_MUX                              ((uint32_t) (0x00000002))
+#define FIFO_CTRL_PUSH_INT_MUX                         ((uint32_t) (0x00000003))
+#define FIFO_CTRL_POP_INT_MUX                          ((uint32_t) (0x00000004))
+#define FIFO_CTRL_FFE_SEL                              ((uint32_t) (0x00000005))
+
+#define FIFOx_CTRL_ENABLE(FIFO_INDEX)                  (PKFB->PKFB_FIFOCTRL |= 1<<((FIFO_INDEX * 8) + FIFO_CTRL_ENABLE))
+#define FIFOx_CTRL_DISABLE(FIFO_INDEX)                 (PKFB->PKFB_FIFOCTRL &= (~1<<((FIFO_INDEX * 8)+ FIFO_CTRL_ENABLE)))
+
+#define FIFOx_CTRL_PUSH_FFE(FIFO_INDEX)                (PKFB->PKFB_FIFOCTRL |= 1<<((FIFO_INDEX * 8) + FIFO_CTRL_PUSH_MUX))
+#define FIFOx_CTRL_PUSH_M4(FIFO_INDEX)                 (PKFB->PKFB_FIFOCTRL &= ~(1<<((FIFO_INDEX * 8) + FIFO_CTRL_PUSH_MUX))); (PKFB->PKFB_FIFOCTRL &= ~(1<<((FIFO_INDEX * 8) + FIFO_CTRL_POP_INT_MUX)))
+
+#define FIFOx_CTRL_POP_AP(FIFO_INDEX)                  (PKFB->PKFB_FIFOCTRL |= 1<<((FIFO_INDEX * 8) + FIFO_CTRL_POP_MUX)); (PKFB->PKFB_FIFOCTRL |= 1<<((FIFO_INDEX * 8) + FIFO_CTRL_PUSH_INT_MUX))
+#define FIFOx_CTRL_POP_M4(FIFO_INDEX)                  (PKFB->PKFB_FIFOCTRL &= ~(1<<((FIFO_INDEX * 8) + FIFO_CTRL_POP_MUX))); (PKFB->PKFB_FIFOCTRL &= ~(1<<((FIFO_INDEX * 8) + FIFO_CTRL_PUSH_INT_MUX)))
+
+#define FIFOx_CTRL_FFE0_SEL(FIFO_INDEX)                (FIFOx_CTRL_PUSH_FFE(FIFO_INDEX)); (PKFB->PKFB_FIFOCTRL &= ~(1<<((FIFO_INDEX * 8) + FIFO_CTRL_FFE_SEL)))
+#define FIFOx_CTRL_FFE1_SEL(FIFO_INDEX)                (FIFOx_CTRL_PUSH_FFE(FIFO_INDEX)); (PKFB->PKFB_FIFOCTRL |= (1<<((FIFO_INDEX * 8) + FIFO_CTRL_FFE_SEL)))
+
+#define FIFOx_CTRL_RESET(FIFO_INDEX)                   (PKFB->PKFB_FIFOCTRL &= ~(0xFF<<(FIFO_INDEX * 8)))
+
+/* Macros and bit definition for FIFO Status register */
+#define FIFO_STATUS_SRAM_SLEEP_ON                      (0x00000000)
+#define FIFO_STATUS_SRAM_SLEEP_LS                      (0x00000001)
+#define FIFO_STATUS_SRAM_SLEEP_DS                      (0x00000002)
+#define FIFO_STATUS_SRAM_SLEEP_SD                      (0x00000003)
+#define FIFO_STATUS_PUSH_INT_OVER                      (0x00000004)
+#define FIFO_STATUS_PUSH_INT_THRESH                    (0x00000008)
+#define FIFO_STATUS_PUSH_INT_SLEEP                     (0x00000010)
+#define FIFO_STATUS_POP_INT_UNDER                      (0x00000020)
+#define FIFO_STATUS_POP_INT_THRESH                     (0x00000040)
+#define FIFO_STATUS_POP_INT_SLEEP                      (0x00000080)
+
+
+#define FIFOx_STATUS_SRAM_SLEEP(FIFO_INDEX)            (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_SRAM_SLEEP_SD)<<(FIFO_INDEX * 8))
+
+#define IS_FIFOx_STATUS_SRAM_ACTIVE(FIFO_INDEX)        (!FIFOx_STATUS_SRAM_SLEEP(FIFO_INDEX)?1:0)
+#define IS_FIFOx_STATUS_SRAM_LS(FIFO_INDEX)            (FIFOx_STATUS_SRAM_SLEEP(FIFO_INDEX) == (FIFO_STATUS_SRAM_SLEEP_LS)<<(FIFO_INDEX * 8)? 1:0)
+#define IS_FIFOx_STATUS_SRAM_DS(FIFO_INDEX)            (FIFOx_STATUS_SRAM_SLEEP(FIFO_INDEX) == (FIFO_STATUS_SRAM_SLEEP_DS)<<(FIFO_INDEX * 8)? 1:0)
+#define IS_FIFOx_STATUS_SRAM_SD(FIFO_INDEX)            (FIFOx_STATUS_SRAM_SLEEP(FIFO_INDEX) == (FIFO_STATUS_SRAM_SLEEP_SD)<<(FIFO_INDEX * 8)? 1:0)
+
+
+#define FIFOx_STATUS_CLEAR_PUSH_INT_OVER(FIFO_INDEX)   (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_PUSH_INT_OVER)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_PUSH_INT_OVER(FIFO_INDEX)    (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_PUSH_INT_OVER)<<(FIFO_INDEX * 8))
+
+#define FIFOx_STATUS_CLEAR_PUSH_INT_THRESH(FIFO_INDEX) (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_PUSH_INT_THRESH)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_PUSH_INT_THRESH(FIFO_INDEX)  (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_PUSH_INT_THRESH)<<(FIFO_INDEX * 8))
+
+#define FIFOx_STATUS_CLEAR_PUSH_INT_SLEEP(FIFO_INDEX)  (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_PUSH_INT_SLEEP)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_PUSH_INT_SLEEP(FIFO_INDEX)   (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_PUSH_INT_SLEEP)<<(FIFO_INDEX * 8))
+
+#define FIFOx_STATUS_CLEAR_POP_INT_UNDER(FIFO_INDEX)   (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_POP_INT_UNDER)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_POP_INT_UNDER(FIFO_INDEX)    (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_POP_INT_UNDER)<<(FIFO_INDEX * 8))
+
+#define FIFOx_STATUS_CLEAR_POP_INT_THRESH(FIFO_INDEX)  (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_POP_INT_THRESH)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_POP_INT_THRESH(FIFO_INDEX)   (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_POP_INT_THRESH)<<(FIFO_INDEX * 8))
+
+#define FIFOx_STATUS_CLEAR_POP_INT_SLEEP(FIFO_INDEX)   (PKFB->PKFB_FIFOSTATUS |= (FIFO_STATUS_POP_INT_SLEEP)<<(FIFO_INDEX * 8))
+#define FIFOx_STATUS_READ_POP_INT_SLEEP(FIFO_INDEX)    (PKFB->PKFB_FIFOSTATUS & (FIFO_STATUS_POP_INT_SLEEP)<<(FIFO_INDEX * 8))
+
+/* Macros and bit definition for FIFO PUSH control register */
+#define FIFO_SLEEP_EN                                  (0)
+#define FIFO_SLEEP_TYPE                                (1)
+#define FIFO_INT_OVER_UNDER                            (2)
+#define FIFO_INT_THRESH                                (3)
+#define FIFO_INT_SRAM_SLEEP                            (4)
+#define FIFO_THRESH                                    (16)
+
+#define FIFOx_PUSH_SLEEP_ENABLE(FIFO_INDEX)            (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= 1<<FIFO_SLEEP_EN)
+#define FIFOx_PUSH_SLEEP_DISABLE(FIFO_INDEX)           (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_SLEEP_EN))
+
+//#define FIFOx_PUSH_SLEEP_DS(FIFO_INDEX)                (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_SLEEP_TYPE))
+//#define FIFOx_PUSH_SLEEP_SD(FIFO_INDEX)                (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_SLEEP_TYPE))
+
+#define FIFOx_PUSH_INT_OVER_ENABLE(FIFO_INDEX)         (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_OVER_UNDER))
+#define FIFOx_PUSH_INT_OVER_DISABLE(FIFO_INDEX)        (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_OVER_UNDER))
+
+#define FIFOx_PUSH_INT_THRESH_ENABLE(FIFO_INDEX)       (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_THRESH))
+#define FIFOx_PUSH_INT_THRESH_DISABLE(FIFO_INDEX)      (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_THRESH))
+
+#define FIFOx_PUSH_INT_SRAM_SLEEP_ENABLE(FIFO_INDEX)   (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_SRAM_SLEEP))
+#define FIFOx_PUSH_INT_SRAM_SLEEP_DISABLE(FIFO_INDEX)  (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_SRAM_SLEEP))
+
+#define FIFOx_PUSH_THRESHOLD(FIFO_INDEX, COUNT)        (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) |= (COUNT<<FIFO_THRESH))
+#define FIFOx_PUSH_THRESHOLD_RESET(FIFO_INDEX)         (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) &= ~(0x1FF<<FIFO_THRESH))
+
+#define FIFOx_PUSH_CTRL_RESET(FIFO_INDEX)              (*(&PKFB->PKFB_PF0PUSHCTRL+ FIFO_INDEX*0x4) = 0)
+
+/* Macros and bit definition for FIFO POP control register */
+#define FIFOx_POP_SLEEP_ENABLE(FIFO_INDEX)             (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= 1<<FIFO_SLEEP_EN)
+#define FIFOx_POP_SLEEP_DISABLE(FIFO_INDEX)            (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_SLEEP_EN))
+
+#define FIFOx_POP_SLEEP_DS(FIFO_INDEX)                 (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_SLEEP_TYPE))
+#define FIFOx_POP_SLEEP_SD(FIFO_INDEX)                 (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_SLEEP_TYPE))
+
+#define FIFOx_POP_INT_OVER_ENABLE(FIFO_INDEX)          (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_OVER_UNDER))
+#define FIFOx_POP_INT_OVER_DISABLE(FIFO_INDEX)         (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_OVER_UNDER))
+
+#define FIFOx_POP_INT_THRESH_ENABLE(FIFO_INDEX)        (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_THRESH))
+#define FIFOx_POP_INT_THRESH_DISABLE(FIFO_INDEX)       (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_THRESH))
+
+#define FIFOx_POP_INT_SRAM_SLEEP_ENABLE(FIFO_INDEX)    (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= (1<<FIFO_INT_SRAM_SLEEP))
+#define FIFOx_POP_INT_SRAM_SLEEP_DISABLE(FIFO_INDEX)   (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(1<<FIFO_INT_SRAM_SLEEP))
+
+#define FIFOx_POP_THRESHOLD(FIFO_INDEX, COUNT)         (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) |= (COUNT<<FIFO_THRESH))
+#define FIFOx_POP_THRESHOLD_RESET(FIFO_INDEX)          (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) &= ~(0x1FF<<FIFO_THRESH))
+
+#define FIFOx_POP_RESET(FIFO_INDEX)                    (*(&PKFB->PKFB_PF0POPCTRL+ FIFO_INDEX*0x4) = 0)
+
+/* Macros and bit definition for FIFO count register */
+#define FIFO_COUNT                                     (0x000001FF)
+#define FIFO_PUSH_OFFSET                               (16)
+#define FIFO_EMPTY_MASK                                (15)
+#define FIFO_FULL_MASK                                 (31)
+
+
+#define FIFOx_GET_POP_COUNT(FIFO_INDEX)                (*(&PKFB->PKFB_PF0CNT + FIFO_INDEX*0x4) & FIFO_COUNT)
+#define FIFOx_GET_PUSH_COUNT(FIFO_INDEX)               ((*(&PKFB->PKFB_PF0CNT + FIFO_INDEX*0x4)>>FIFO_PUSH_OFFSET) & FIFO_COUNT)
+
+#define IS_FIFO_EMPTY(FIFO_INDEX)                      (*(&PKFB->PKFB_PF0CNT + FIFO_INDEX*0x4) & (1<<FIFO_EMPTY_MASK))
+#define IS_FIFO_FULL(FIFO_INDEX)                       (*(&PKFB->PKFB_PF0CNT + FIFO_INDEX*0x4) & (1<<FIFO_FULL_MASK))
+
+/* Macros for FIFO data register */
+#define FIFOx_DATA_WRITE(FIFO_INDEX, VALUE)            (*(&PKFB->PKFB_PF0DATA + FIFO_INDEX*0x4) |= VALUE)
+#define FIFOx_DATA_READ(FIFO_INDEX)                    (*(&PKFB->PKFB_PF0DATA + FIFO_INDEX*0x4))
+
+/* Add FIFO collision macros and bit definitions */
+
+///@endcond PKFB_MACROS
+
+/*! \struct FIFO_Config eoss3_hal_pkfb.h "inc/eoss3_hal_pkfb.h"
+ * 	\brief FIFO configuration for PUSH source and POP destination.
+ */
+typedef struct
+{
+	FIFO_Type     eFifoID;                              /*!< FIFO number to configure */
+	FIFO_SrcType  eSrc;                                 /*!< FIFO PUSH source */
+	FIFO_DestType eDest;                                /*!< FIFO POP destination */
+}FIFO_Config;
+
+/*! \struct FIFO_IntConfig eoss3_hal_pkfb.h "inc/eoss3_hal_pkfb.h"
+ * 	\brief FIFO interrupt configuration for PUSH and POP side.
+ */
+typedef struct
+{
+	FIFO_DestType    ePushIntMux;                       /*!< FIFO owner that should receive PUSH interrupts */
+	FIFO_DestType    ePopIntMux;                        /*!< FIFO owner that should receive POP interrupts */
+	FIFO_PushIntType ePushIntType;                      /*!< FIFO PUSH side interrupts type */
+	FIFO_PushIntType ePopIntType;                       /*!< FIFO POP side interrupt types */
+	UINT32_t         uiPushThresholdCount;              /*!< Threshold in words to generate PUSH side interrupt */
+	UINT32_t         uiPopThresholdCount;               /*!< Threshold in workds to generate POP side interrupt */
+}FIFO_IntConfig;
+
+/* Exported functions --------------------------------------------------------*/
+/*! \fn void HAL_FIFO_Enable(FIFO_Type eFifoID)
+ *  \brief Enable FIFO for PUSH/POP operation.
+ *
+ *  \param eFifoID             FIFO ID to enable
+ */
+void HAL_FIFO_Enable(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_Disable(FIFO_Type eFifoID)
+ *  \brief Enable FIFO for PUSH/POP operation.
+ *
+ *  \param eFifoID             FIFO ID to disable
+ */
+void HAL_FIFO_Disable(FIFO_Type eFifoID);
+
+
+/*! \fn UINT32_t HAL_FIFO_Read(FIFO_Type eFifoID, INT32_t iLen, UINT32_t *puiRxBuf)
+ *  \brief Read data from FIFO.
+ * 
+ *  \param eFifoID             FIFO ID to read from
+ *  \param iLen                number of 32 bit words to read
+ *  \param puiRxBuf            pointer to buffer where data has to be read
+ *  \return UINT32_t            Number of 32-bit words read from FIFO
+ */
+UINT32_t HAL_FIFO_Read(FIFO_Type eFifoID, INT32_t iLen, UINT32_t *puiRxBuf);
+
+
+/*! \fn UINT32_t HAL_FIFO8K_Read(FIFO_Type eFifoID, INT32_t iLen, UINT16_t *pusRxBuf)
+ *  \brief Read data from 8K FIFO.
+ * 
+ *  \param eFifoID             FIFO ID of 8K FIFO
+ *  \param iLen                number of 16 bit words to read
+ *  \param pusRxBuf            pointer to buffer where data has to be read
+ *  \return UINT32_t            Number of 16-bit words read from FIFO
+ */
+UINT32_t HAL_FIFO8K_Read(FIFO_Type eFifoID, INT32_t iLen, UINT16_t *pusRxBuf);
+
+
+/*! \fn UINT32_t HAL_FIFO_Write(FIFO_Type eFifoID, INT32_t iLen, UINT32_t *puiTxBuf)
+ *  \brief Write data to FIFO.
+ * 
+ *  \param eFifoID             FIFO ID to write
+ *  \param iLen                number of 32 bit words to write
+ *  \param puiTxBuf            pointer to buffer with data to be written to FIFO
+ *  \return UINT32_t            Number of 32-bit words written to FIFO
+ */
+UINT32_t HAL_FIFO_Write(FIFO_Type eFifoID, INT32_t iLen, UINT32_t *puiTxBuf);
+
+
+/*! \fn UINT32_t HAL_FIFO8K_Write(FIFO_Type eFifoID, INT32_t iLen, UINT16_t *pusTxBuf)
+ *  \brief Write data to 8K FIFO.
+ * 
+ *  \param eFifoID             FIFO ID of 8K FIFO to write
+ *  \param iLen                number of 16 bit words to write
+ *  \param pusTxBuf            pointer to buffer with data to be written to FIFO
+ *  \return UINT32_t           Number of 16-bit words written to FIFO
+ */
+UINT32_t HAL_FIFO8K_Write(FIFO_Type eFifoID, INT32_t iLen, UINT16_t *pusTxBuf);
+
+
+/*! \fn void HAL_FIFO_PushSleepEnable(FIFO_Type eFifoID)
+ *  \brief Enable sleep mode on PUSH side of FIFO.
+ *
+ *  \param eFifoID             FIFO ID to enable PUSH side sleep mode
+ */
+void HAL_FIFO_PushSleepEnable(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_PushSleepDisable(FIFO_Type eFifoID)
+ *  \brief Disable sleep mode on PUSH side of FIFO.
+ *
+ *  \param eFifoID             FIFO ID to disable PUSH side sleep mode
+ */
+void HAL_FIFO_PushSleepDisable(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_PopSleepEnable(FIFO_Type eFifoID)
+ *  \brief Enable sleep mode on POP side of FIFO.
+ *
+ *  \param eFifoID           	FIFO ID to enable POP side sleep mode
+ */
+void HAL_FIFO_PopSleepEnable(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_PopSleepDisable(FIFO_Type eFifoID)
+ *  \brief Disable sleep mode on POP side of FIFO.
+ *
+ *  \param eFifoID             FIFO ID to disable POP side sleep mode
+ */
+void HAL_FIFO_PopSleepDisable(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_PopCount(FIFO_Type eFifoID)
+ *  \brief Number of words available in FIFO to pop.
+ *
+ *  \param eFifoID             FIFO ID to read available word count for POP
+ */
+UINT32_t HAL_FIFO_PopCount(FIFO_Type eFifoID);
+
+
+/*! \fn void HAL_FIFO_PushCount(FIFO_Type eFifoID)
+ *  \brief Number of words available for PUSH operation in FIFO.
+ *
+ *  \param eFifoID             FIFO ID to read available word count for PUSH
+ */
+UINT32_t HAL_FIFO_PushCount(FIFO_Type eFifoID);
+
+
+/*! \fn HAL_StatusTypeDef HAL_FIFO_Init(FIFO_Config xFifoConfig)
+ *  \brief Initialize FIFO source and destination for PUSH and POP operation.
+ *
+ *  \param xFifoConfig         FIFO_Config structure filled by user to initialize FIFO
+ *  \return HAL_StatusTypeDef   Status of FIFO initialization. HAL_OK or HAL_ERROR.
+ */
+HAL_StatusTypeDef HAL_FIFO_Init(FIFO_Config xFifoConfig);
+
+/*! \fn HAL_StatusTypeDef HAL_FIFO_ConfigInt(FIFO_IntConfig xFifoIntConfig)
+ *  \brief Initialize FIFO interrupts for different conditions. i.e. overflow, underflow
+ *         threshold, sleep etc.
+ *
+ *  \param xFifoIntConfig      FIFO_Config structure filled by user to initialize FIFO
+ *  \return HAL_StatusTypeDef   Status of FIFO interrupt configuration. HAL_OK or HAL_ERROR.
+ */
+HAL_StatusTypeDef HAL_FIFO_ConfigInt(FIFO_IntConfig xFifoIntConfig);
+
+
+/*! \fn void HAL_FIFO_ClkInit(FIFO_Type eFifoID)
+ *  \brief Initialize clock for FIFO.
+ *
+ *  \param eFifoID             FIFO ID to initialize clock
+ */
+void HAL_FIFO_ClkInit(FIFO_Type eFifoID);
+
+/*! \fn void HAL_FIFO_ClkDeInit(FIFO_Type eFifoID)
+ *  \brief Disable clock for FIFO.
+ *
+ *  \param eFifoID             FIFO ID to disable clock
+ */
+void HAL_FIFO_ClkDeInit(FIFO_Type eFifoID);
+
+/*! \fn HAL_StatusTypeDef HAL_FIFO_PowerInit(FIFO_Type eFifoID)
+ *  \brief Initialize power for FIFO.
+ *
+ *  \param eFifoID             FIFO ID to initialize power
+ *  \return HAL_StatusTypeDef   Status of power initialization of FIFO. HAL_OK or HAL_ERROR.
+ */
+HAL_StatusTypeDef HAL_FIFO_PowerInit(FIFO_Type eFifoID);
+
+#endif /* __EOSS3_HAL_PKFB_H_ */

--- a/HAL/inc/eoss3_hal_pmu_timer.h
+++ b/HAL/inc/eoss3_hal_pmu_timer.h
@@ -1,0 +1,46 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_pmu_timer.h
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             for M4 peripheral timer
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_INC_EOSS3_HAL_PMU_TIMER_H_
+#define HAL_INC_EOSS3_HAL_PMU_TIMER_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+
+typedef struct __PMU_Timer_HandleTypeDef
+{
+     UINT32_t   timerReload_val;
+     void (*timer_callback) (void *args);
+}PMU_Timer_HandleTypeDef;
+   
+#define MAX_TIMER_COUNT  1
+#define MSEC_PER_TICK   1.953125f
+
+HAL_StatusTypeDef HAL_PMU_Set_Timer(UINT32_t timerLoadVal, void (*callbackFn) (void *args));
+UINT32_t HAL_PMU_Disable_Timer( );
+HAL_StatusTypeDef HAL_PMU_Timer_Interrupt_Callback();
+
+#endif /* HAL_INC_EOSS3_HAL_PMU_TIMER_H_ */

--- a/HAL/inc/eoss3_hal_rtc.h
+++ b/HAL/inc/eoss3_hal_rtc.h
@@ -1,0 +1,53 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_rtc.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+#ifndef __EOSS3_HAL_RTC_H__
+#define __EOSS3_HAL_RTC_H__
+#include <stdio.h>
+#include "eoss3_hal_def.h"
+
+/*
+ * HAL_RTC_Init : Initializes the rtc with the value uiInitialRTCTimeValueSecs.
+ * This call can happen only once & same is taken care inside this api. Second
+ * time call will not have any effect.
+ * RTC will start counting from this value. This value can be changed in runtime
+ * using API HAL_RTC_SetTime
+ */
+HAL_StatusTypeDef HAL_RTC_Init(uint32_t uiInitialRTCTimeValueSecs);
+
+/*
+ * HAL_RTC_SetupAlarm : Setup RTC to interrupt every "rtc_alarm_interval" seconds & call
+ * rtc_cb
+ */
+HAL_StatusTypeDef HAL_RTC_SetupAlarm(uint32_t rtc_alarm_interval, void (*rtc_cb)(void));
+
+/*
+ * HAL_RTC_SetTime : RTC will start counting from the value uiRTCValueSecs
+ */
+HAL_StatusTypeDef HAL_RTC_SetTime(uint32_t uiRTCValueSecs);
+
+/*
+ * HAL_RTC_GetTime : RTC will return current seconds counted in uiRTCValueSecs
+ */
+HAL_StatusTypeDef HAL_RTC_GetTime(uint32_t *uiRTCValueSecs);
+
+void HAL_RTC_ISR(void);
+
+#endif

--- a/HAL/inc/eoss3_hal_sdma.h
+++ b/HAL/inc/eoss3_hal_sdma.h
@@ -1,0 +1,65 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_sdma.h
+ *    Purpose   : 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_SDMA_H_
+#define __EOSS3_HAL_SDMA_H_
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+typedef enum
+{
+    SDMA_XFER_INVALID = 0,
+    SDMA_XFER_BYTE,
+    SDMA_XFER_HWORD,
+    SDMA_XFER_WORD
+} SDMA_XFER_FORMAT;
+
+/*!
+ * @brief Supported HAL SDMA Address location width sizes
+ */
+typedef enum
+{
+    SDMA_ADDR_WIDTH_BYTE,
+    SDMA_ADDR_WIDTH_HWORD,
+    SDMA_ADDR_WIDTH_WORD,
+    SDMA_ADDR_WIDTH_NOINC
+} SDMA_ADDR_WIDTH;
+
+/**
+  * @brief SDMA Channel properties structure
+  */
+typedef struct
+{
+   SDMA_XFER_FORMAT data_size;   /* source and destination should have same data size */
+   SDMA_ADDR_WIDTH  src_addr_inc;
+   SDMA_ADDR_WIDTH  dest_addr_inc;
+   uint32_t         rpowerCode;
+} SDMA_ch_cfg_t;
+
+HAL_StatusTypeDef HAL_SDMA_Init(void);
+//32 bit transfer
+HAL_StatusTypeDef HAL_SDMA_xferWord(int chan, uint32_t * srcptr, uint32_t *dstptr, int wordLen);
+HAL_StatusTypeDef HAL_SDMA_xfer(int chan, uint32_t * srcptr, uint32_t *dstptr, int wordLen, SDMA_ch_cfg_t *chCfg);
+HAL_StatusTypeDef HAL_SDMA_Register_FPGA_DmaChan_Comp_Notifier(void (*comp_notifier)(void*));
+HAL_StatusTypeDef HAL_SDMA_Reg_CB(int channel_number, void (*triggerSdma)(int chan),  void (*comp_notifier)(int chan));
+
+
+#endif /* __EOSS3_HAL_SDMA_H_ */

--- a/HAL/inc/eoss3_hal_spi-p4org.h
+++ b/HAL/inc/eoss3_hal_spi-p4org.h
@@ -1,0 +1,288 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_spi-p4org.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef TAMAR_HAL_SPI_H_
+#define TAMAR_HAL_SPI_H_
+
+#include <common.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#include "eoss3_hal_def.h"
+#include "Alg_types.h"
+
+#define assert_param(expr)  	((expr) ? (void)0 : assert_failed((UINT8_t*)__FILE__,__LINE__))
+
+
+/*!
+ * HAL SPI State structure definition
+ */
+typedef enum
+{
+	HAL_SPI_STATE_RESET=0,		/*! SPI not yet initialized or disabled */
+	HAL_SPI_STATE_READY,		/*! SPI initialized and ready for use 	*/
+	HAL_SPI_STATE_TX_BUSY,		/*! SPI Data transmission process is ongoing  */
+	HAL_SPI_STATE_RX_BUSY,		/*! SPI Reception process is ongoing */
+	HAL_SPI_STATE_TX_RX_BUSY,
+	HAL_SPI_STATE_ERROR
+}HAL_SPI_StateTypeDef;
+
+typedef enum
+{
+	SPI_MODE_0 = 0,
+	SPI_MODE_1,
+	SPI_MODE_2,
+	SPI_MODE_3,
+	SPI_MODE_INVALID,
+}SpiMode;
+
+typedef enum {
+	CMD_WithResponse = 0,
+	CMD_NoResponse,
+	READ_CMD,
+	PROGRAM_CMD,
+}FlashCmdType;
+
+
+// Return Message
+typedef enum {
+    FlashOperationSuccess=1,
+    FlashWriteRegFailed,
+    FlashTimeOut,
+    FlashIsBusy,
+    FlashQuadNotEnable,
+    FlashAddressInvalid,
+    FlashInvalidParams,
+    FlashCmdFailed,
+    FlashMatchFound,
+    FlashNotFound,
+}ReturnMsg;
+
+
+                                                                                        /*! Sensor SPI Master PAD selection.
+											If ucSPI0PadSel = 0 then, SPI_MOSI--> PAD6, SPI_MISO--> PAD8, SPI_CLK--> PAD10, SPI_SSN1--> PAD9,
+																	  SPI_SSN2--> PAD2, SPI_SSN3--> PAD4, SPI_SSN4--> PAD5, SPI_SSN5--> PAD7,
+																	  SPI_SSN6--> PAD11, SPI_SSN7--> PAD12, SPI_SSN8--> PAD13
+
+											If ucSPI0PadSel = 1 then, SPI_MOSI--> PAD28, SPI_MISO--> PAD29, SPI_CLK--> PAD31, SPI_SSN1--> PAD30,
+																	  SPI_SSN2--> PAD36, SPI_SSN3--> PAD4, SPI_SSN4--> PAD26, SPI_SSN5--> PAD27,
+																	  SPI_SSN6--> PAD33, SPI_SSN7--> PAD35, SPI_SSN8--> PAD37
+											*/
+
+
+/*!
+ * \brief SPI Configuration Structure definition
+ */
+typedef struct
+{
+	UINT8_t  		ucSPIInf;			/*! SPI Interface : ucSPIInf = 0 (4-wire), ucSPIInf = 1 (3-wire) interface */
+	SpiMode	 		ucSPIMode;			/*! SPI transfer mode, mode 0 - 3 */
+	FlashCmdType	ucCmdType;			/*! SPI Flash command type */
+	UINT8_t			ucSSn;				/*! SPI slave select pin */
+	UINT32_t		ucFreq;				/*! SPI Communication Frequency */
+	UINT32_t 		ulDataSize;			/*! Specifies the SPI data size.*/
+	UINT32_t 		ulCLKPolarity;		/*! Specifies the serial clock steady state.*/
+	UINT32_t 		ulCLKPhase;			/*! Specifies the clock active edge for the bit capture. */
+	UINT32_t 		ulFirstBit;			/*! Specifies whether data transfers start from MSB or LSB bit. */
+    uint8_t         fRawMode;           /*! Tim: turns off wierd behavior */
+}SPI_InitTypeDef;
+
+
+/*!
+ * \brief SPI Handle structure definition
+ */
+typedef struct __SPI_HandleTypeDef
+{
+	SPI_InitTypeDef 			Init;			/*! SPI Communication Parameters */
+	UINT8_t 					ucSPIx;			/*! SPI Master index for base address*/
+	UINT8_t 					*pTxBuffer;		/*! Pointer to SPI Tx transfer Buffer */
+	UINT8_t 					*pRxBuffer;		/*! Pointer to SPI Rx transfer Buffer */
+	UINT32_t 					usTxXferCount;	/*! SPI Tx total transfer count */
+	UINT32_t 					usRxXferCount;	/*! SPI Rx total transfer count */
+	UINT32_t 					usTxXferSize;	/*! SPI Tx transfer size for each transfer*/
+	UINT32_t 					usRxXferSize;	/*! SPI Rx transfer size */
+	HAL_SPI_StateTypeDef  		State;        	/*! SPI communication state */
+	void 						(*RxISR)(struct __SPI_HandleTypeDef *spi);	/*! function pointer on Rx ISR */
+	void 						(*TxISR)(struct __SPI_HandleTypeDef *spi);	/*! function pointer on Tx ISR */
+	void 						(*HAL_SPI_TxRxComplCallback)(void);	/*! function pointer on Tx/Rx complete Callback */
+}SPI_HandleTypeDef;
+
+
+/* SPI Transaction size bit definition */
+#define SPI_DATASIZE_8BIT			((UINT8_t)0x7)
+#define SPI_DATASIZE_7BIT			((UINT8_t)0x6)
+#define SPI_DATASIZE_6BIT			((UINT8_t)0x5)
+#define SPI_DATASIZE_5BIT			((UINT8_t)0x4)
+#define SPI_DATASIZE_4BIT			((UINT8_t)0x3)
+#define SPI_DATASIZE_3BIT			((UINT8_t)0x2)
+#define SPI_DATASIZE_2BIT			((UINT8_t)0x1)
+#define SPI_DATASIZE_1BIT			((UINT8_t)0x0)
+#define IS_SPI_DATASIZE(DATASIZE)	((DATASIZE == SPI_DATASIZE_8BIT) || (DATASIZE == SPI_DATASIZE_7BIT) || \
+									 (DATASIZE == SPI_DATASIZE_6BIT) || (DATASIZE == SPI_DATASIZE_5BIT) || \
+									 (DATASIZE == SPI_DATASIZE_4BIT) || (DATASIZE == SPI_DATASIZE_3BIT) || \
+									 (DATASIZE == SPI_DATASIZE_2BIT) || (DATASIZE == SPI_DATASIZE_1BIT))
+
+
+/* SPI Clock Polarity */
+#define SPI_POLARITY_LOW			((UINT8_t)0x0)
+#define SPI_POLARITY_HIGH			((UINT8_t)0x1)
+#define IS_SPI_CPOL(CPOL)			((CPOL == SPI_POLARITY_LOW) || (CPOL == SPI_POLARITY_HIGH))
+
+/* SPI Clock Phase */
+#define SPI_PHASE_1EDGE				((UINT8_t)0x0)
+#define SPI_PHASE_2EDGE				((UINT8_t)0x1)
+#define IS_SPI_CPHA(CPHA)			((CPHA == SPI_PHASE_1EDGE) || (CPHA == SPI_PHASE_2EDGE))
+
+/* SPI_MSB_LSB_transmission */
+#define SPI_FIRSTBIT_MSB			((UINT8_t)0x0)
+#define SPI_FIRSTBIT_LSB			((UINT8_t)0x1)
+#define IS_SPI_FIRST_BIT(BIT)		((BIT == SPI_FIRSTBIT_MSB) || (BIT == SPI_FIRSTBIT_LSB))
+
+/* SPI 3-wire configuration */
+#define SPI_BIDIR_MODE_DIS			((UINT8_t)0x0)
+#define SPI_BIDIR_MODE_EN			((UINT8_t)0x1)
+#define IS_SPI_BIDIR_MODE(MODE)		((MODE == SPI_BIDIR_MODE_DIS) || (MODE == SPI_BIDIR_MODE_EN))
+
+#define SPI_3_WIRE_MODE				(0x1)
+#define SPI_4_WIRE_MODE				(0x0)
+
+/* SPI Interrupt/Status register bit definition */
+#define SPI_XFER_IN_PROGRESS		((UINT8_t)0x4)
+#define SPI_WRITE_XFER_DONE			((UINT8_t)0x2)
+#define SPI_READ_XFER_DONE			((UINT8_t)0x1)
+
+/* SPI Slave select register bit definition */
+#define SPI_SLAVE_1_SELECT			((UINT8_t)0x1 << BYTE_IDX_0)
+#define SPI_SLAVE_2_SELECT			((UINT8_t)0x1 << BYTE_IDX_1)
+#define SPI_SLAVE_3_SELECT			((UINT8_t)0x1 << BYTE_IDX_2)
+#define SPI_SLAVE_4_SELECT			((UINT8_t)0x1 << BYTE_IDX_3)
+#define SPI_SLAVE_5_SELECT			((UINT8_t)0x1 << BYTE_IDX_4)
+#define SPI_SLAVE_6_SELECT			((UINT8_t)0x1 << BYTE_IDX_5)
+#define SPI_SLAVE_7_SELECT			((UINT8_t)0x1 << BYTE_IDX_6)
+#define SPI_SLAVE_8_SELECT			((UINT8_t)0x1 << BYTE_IDX_7)
+
+#define IS_SPI_SSN_VALID(SS)		((SS == SPI_SLAVE_1_SELECT) || (SS == SPI_SLAVE_2_SELECT) || (SS == SPI_SLAVE_3_SELECT) || \
+									 (SS == SPI_SLAVE_4_SELECT) || (SS == SPI_SLAVE_5_SELECT) || (SS == SPI_SLAVE_6_SELECT) || \
+									 (SS == SPI_SLAVE_7_SELECT)	||	(SS == SPI_SLAVE_8_SELECT))
+
+
+#define IS_SPIx_VALID(n)			((n == SPI0_MASTER_SEL) || (n == SPI1_MASTER_SEL))
+
+/*! \def SPI0_MASTER_SEL
+    \brief A macro to select Sensor SPI Master controller in FFE subsystem
+*/
+#define SPI0_MASTER_SEL				0
+
+/*! \def SPI1_MASTER_SEL
+    \brief A macro to select SPI Master controller connected to SPI Flash
+*/
+#define SPI1_MASTER_SEL				1
+
+/*! \def I2C_0_SELECT
+    \brief A macro to select I2C_0 as slave to be accessed by WB master
+*/
+#define I2C_0_SELECT				((UINT8_t)0x0)
+
+/*! \def I2C_1_SELECT
+    \brief A macro to select I2C_1 as slave to be accessed by WB master
+*/
+#define I2C_1_SELECT				((UINT8_t)0x40)
+
+/*! \def SPI_0_SELECT
+    \brief A macro to select SPI_0 as slave to be accessed by WB master
+*/
+#define SPI_0_SELECT				((UINT8_t)0x80)
+
+/*! \def SPI0_MUX_SEL_WB_MASTER
+    \brief A macro to define SPI_0 wishbone control mux select
+*/
+#define SPI0_MUX_SEL_WB_MASTER		((UINT8_t)0x80)
+
+/*!
+ * \brief The following macros define the Sensor SPI Master register offsets
+ */
+#define SPI0_BR_LSB_REG				0x0
+#define SPI0_BR_MSB_REG				0x1
+#define SPI0_CFG_REG				0x2
+#define SPI0_TX_RX_REG				0x3
+#define SPI0_CMD_STS_REG			0x4
+#define SPI0_SS_REG				0x5
+#define SPI0_CLK_CTRL_REG			0x6
+#define SPI0_ADD_CLK_REG			0x7
+
+#define SPI_BAUDRATE_625KHZ			((UINT32_t)625000)
+#define SPI_BAUDRATE_1MHZ			((UINT32_t)1000000)
+#define SPI_BAUDRATE_2_5MHZ			((UINT32_t)2500000)
+#define SPI_BAUDRATE_5MHZ			((UINT32_t)5000000)
+#define SPI_BAUDRATE_10MHZ			((UINT32_t)10000000)
+#define SPI_BAUDRATE_15MHZ                      ((UINT32_t)15000000)
+#define SPI_BAUDRATE_20MHZ                      ((UINT32_t)20000000)
+   
+
+/*!
+ * \brief SPI command register (offset 0x4) bit definition
+ */
+#define SPI_CMD_START				((UINT8_t)(1 << BYTE_IDX_0))
+#define SPI_CMD_STOP				((UINT8_t)(1 << BYTE_IDX_1))
+#define SPI_CMD_WRITE				((UINT8_t)(1 << BYTE_IDX_2))
+#define SPI_CMD_READ				((UINT8_t)(1 << BYTE_IDX_3))
+#define SPI_CMD_IACK				((UINT8_t)(1 << BYTE_IDX_7))
+
+/*!
+ * \brief SPI Interrupt/Status register bit definition
+ */
+#define SPI_STAT_TIP				((UINT8_t) (1 << BYTE_IDX_2))
+#define SPI_INTR_IW				((UINT8_t) (1 << BYTE_IDX_1))
+#define SPI_INTR_IR				((UINT8_t) (1 << BYTE_IDX_0))
+
+
+/*!
+ * \brief SPI configuration register (offset 0x2) bit definition
+ */
+#define SPI_SYSTEM_EN				((UINT8_t)(1 << BYTE_IDX_7))
+#define SPI_INTR_EN				((UINT8_t)(1 << BYTE_IDX_6))
+
+#define SPI_MS_INTR_EN				((UINT32_t)0x40000)
+
+#define SPI1_XFER_LEN_MAX			260
+
+/********************** Exported Functions ********************/
+HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
+void HAL_SPI_IRQHandler(void);
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef  *hspi);
+
+HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef  *hspi);
+
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef  *hspi, UINT8_t *pData, UINT32_t ulTxLen);
+
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, const UINT32_t usTxSize,UINT8_t *pRxData, const UINT32_t usRxSize,void (*HAL_SPI_TxRxComplCallback)(void));
+
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, UINT8_t *pData, UINT32_t ulTxLen, void (*HAL_SPI_Callback)(void));
+
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, UINT32_t usTxSize, UINT8_t *pRxData,UINT32_t usRxSize,
+											void (*HAL_SPI_TxRxComplCallback)(void));
+
+//void SPI_DMA_Complete(SPI_HandleTypeDef  *hspi);
+void SPI_DMA_Complete(void);
+
+
+
+#endif /* TAMAR_HAL_SPI_H_ */

--- a/HAL/inc/eoss3_hal_spi.h
+++ b/HAL/inc/eoss3_hal_spi.h
@@ -1,0 +1,395 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_spi.h
+ *    Purpose   : 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef TAMAR_HAL_SPI_H_
+#define TAMAR_HAL_SPI_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "eoss3_hal_def.h"
+#include "test_types.h"
+
+#define assert_param(expr)  	((expr) ? (void)0 : assert_failed(__FILE__,__LINE__))
+
+
+/*!
+ * HAL SPI State structure definition
+ */
+typedef enum
+{
+	HAL_SPI_STATE_RESET=0,		/*! SPI not yet initialized or disabled */
+	HAL_SPI_STATE_READY,		/*! SPI initialized and ready for use 	*/
+	HAL_SPI_STATE_TX_BUSY,		/*! SPI Data transmission process is ongoing  */
+	HAL_SPI_STATE_RX_BUSY,		/*! SPI Reception process is ongoing */
+	HAL_SPI_STATE_TX_RX_BUSY,
+	HAL_SPI_STATE_ERROR
+}HAL_SPI_StateTypeDef;
+
+typedef enum
+{
+	SPI_MODE_0 = 0,
+	SPI_MODE_1,
+	SPI_MODE_2,
+	SPI_MODE_3,
+	SPI_MODE_INVALID,
+}SpiMode;
+
+typedef enum {
+	CMD_WithResponse = 0,
+	CMD_NoResponse,
+	READ_CMD,
+	PROGRAM_CMD,
+}FlashCmdType;
+
+
+// Return Message
+typedef enum {
+    FlashOperationSuccess=1,
+    FlashWriteRegFailed,
+    FlashTimeOut,
+    FlashIsBusy,
+    FlashQuadNotEnable,
+    FlashAddressInvalid,
+    FlashInvalidParams,
+    FlashCmdFailed,
+    FlashMatchFound,
+    FlashNotFound,
+}ReturnMsg;
+
+
+/*! Sensor SPI Master PAD selection.
+If ucSPI0PadSel = 0 then,
+SPI_MOSI--> PAD6, SPI_MISO--> PAD8, SPI_CLK--> PAD10, SPI_SSN1--> PAD9,
+SPI_SSN2--> PAD2, SPI_SSN3--> PAD4, SPI_SSN4--> PAD5, SPI_SSN5--> PAD7,
+SPI_SSN6--> PAD11, SPI_SSN7--> PAD12, SPI_SSN8--> PAD13
+
+If ucSPI0PadSel = 1 then,
+SPI_MOSI--> PAD28, SPI_MISO--> PAD29, SPI_CLK--> PAD31, SPI_SSN1--> PAD30,
+SPI_SSN2--> PAD36, SPI_SSN3--> PAD4, SPI_SSN4--> PAD26, SPI_SSN5--> PAD27,
+SPI_SSN6--> PAD33, SPI_SSN7--> PAD35, SPI_SSN8--> PAD37
+*/
+
+
+/*!
+ * \brief SPI Configuration Structure definition
+ */
+typedef struct
+{
+	UINT8_t  		ucSPIInf;			/*! SPI Interface : ucSPIInf = 0 (4-wire), ucSPIInf = 1 (3-wire) interface */
+	FlashCmdType	ucCmdType;			/*! SPI Flash command type */
+	UINT8_t			ucSSn;				/*! SPI slave select pin */
+	UINT32_t		ucFreq;				/*! SPI Communication Frequency */
+	UINT32_t 		ulDataSize;			/*! Specifies the SPI data size.*/
+	UINT32_t 		ulCLKPolarity;		/*! Specifies the serial clock steady state.*/
+	UINT32_t 		ulCLKPhase;			/*! Specifies the clock active edge for the bit capture. */
+	UINT32_t 		ulFirstBit;			/*! Specifies whether data transfers start from MSB or LSB bit. */
+}SPI_InitTypeDef;
+
+
+/*!
+ * \brief SPI Handle structure definition
+ */
+typedef struct __SPI_HandleTypeDef
+{
+	SPI_InitTypeDef 			Init;			/*! SPI Communication Parameters */
+	UINT8_t 					ucSPIx;			/*! SPI Master index for base address*/
+	UINT8_t 					*pTxBuffer;		/*! Pointer to SPI Tx transfer Buffer */
+	UINT8_t 					*pRxBuffer;		/*! Pointer to SPI Rx transfer Buffer */
+	UINT32_t 					usTxXferCount;	/*! SPI Tx total transfer count */
+	UINT32_t 					usRxXferCount;	/*! SPI Rx total transfer count */
+	UINT32_t 					usTxXferSize;	/*! SPI Tx transfer size for each transfer*/
+	UINT32_t 					usRxXferSize;	/*! SPI Rx transfer size */
+	HAL_SPI_StateTypeDef  		State;        	/*! SPI communication state */
+	void 						(*RxISR)(struct __SPI_HandleTypeDef *spi);	/*! function pointer on Rx ISR */
+	void 						(*TxISR)(struct __SPI_HandleTypeDef *spi);	/*! function pointer on Tx ISR */
+	void 						(*HAL_SPI_TxRxComplCallback)(void);	/*! function pointer on Tx/Rx complete Callback */
+}SPI_HandleTypeDef;
+
+
+/* SPI Transaction size bit definition */
+#define SPI_DATASIZE_8BIT			((UINT8_t)0x7)
+#define SPI_DATASIZE_7BIT			((UINT8_t)0x6)
+#define SPI_DATASIZE_6BIT			((UINT8_t)0x5)
+#define SPI_DATASIZE_5BIT			((UINT8_t)0x4)
+#define SPI_DATASIZE_4BIT			((UINT8_t)0x3)
+#define SPI_DATASIZE_3BIT			((UINT8_t)0x2)
+#define SPI_DATASIZE_2BIT			((UINT8_t)0x1)
+#define SPI_DATASIZE_1BIT			((UINT8_t)0x0)
+#define IS_SPI_DATASIZE(DATASIZE)	((DATASIZE == SPI_DATASIZE_8BIT) || (DATASIZE == SPI_DATASIZE_7BIT) || \
+									 (DATASIZE == SPI_DATASIZE_6BIT) || (DATASIZE == SPI_DATASIZE_5BIT) || \
+									 (DATASIZE == SPI_DATASIZE_4BIT) || (DATASIZE == SPI_DATASIZE_3BIT) || \
+									 (DATASIZE == SPI_DATASIZE_2BIT) || (DATASIZE == SPI_DATASIZE_1BIT))
+
+
+/* SPI Clock Polarity */
+#define SPI_POLARITY_LOW			((UINT8_t)0x0)
+#define SPI_POLARITY_HIGH			((UINT8_t)0x1)
+#define IS_SPI_CPOL(CPOL)			((CPOL == SPI_POLARITY_LOW) || (CPOL == SPI_POLARITY_HIGH))
+
+/* SPI Clock Phase */
+#define SPI_PHASE_1EDGE				((UINT8_t)0x0)
+#define SPI_PHASE_2EDGE				((UINT8_t)0x1)
+#define IS_SPI_CPHA(CPHA)			((CPHA == SPI_PHASE_1EDGE) || (CPHA == SPI_PHASE_2EDGE))
+
+/* SPI_MSB_LSB_transmission */
+#define SPI_FIRSTBIT_MSB			((UINT8_t)0x0)
+#define SPI_FIRSTBIT_LSB			((UINT8_t)0x1)
+#define IS_SPI_FIRST_BIT(BIT)		((BIT == SPI_FIRSTBIT_MSB) || (BIT == SPI_FIRSTBIT_LSB))
+
+/* SPI 3-wire configuration */
+#define SPI_BIDIR_MODE_DIS			((UINT8_t)0x0)
+#define SPI_BIDIR_MODE_EN			((UINT8_t)0x1)
+#define IS_SPI_BIDIR_MODE(MODE)		((MODE == SPI_BIDIR_MODE_DIS) || (MODE == SPI_BIDIR_MODE_EN))
+
+#define SPI_3_WIRE_MODE				(0x1)
+#define SPI_4_WIRE_MODE				(0x0)
+
+/* SPI Interrupt/Status register bit definition */
+#define SPI_XFER_IN_PROGRESS		((UINT8_t)0x4)
+#define SPI_WRITE_XFER_DONE			((UINT8_t)0x2)
+#define SPI_READ_XFER_DONE			((UINT8_t)0x1)
+
+/* SPI Slave select register bit definition */
+#define SPI_SLAVE_1_SELECT			((UINT8_t)0x1 << BYTE_IDX_0)
+#define SPI_SLAVE_2_SELECT			((UINT8_t)0x1 << BYTE_IDX_1)
+#define SPI_SLAVE_3_SELECT			((UINT8_t)0x1 << BYTE_IDX_2)
+#define SPI_SLAVE_4_SELECT			((UINT8_t)0x1 << BYTE_IDX_3)
+#define SPI_SLAVE_5_SELECT			((UINT8_t)0x1 << BYTE_IDX_4)
+#define SPI_SLAVE_6_SELECT			((UINT8_t)0x1 << BYTE_IDX_5)
+#define SPI_SLAVE_7_SELECT			((UINT8_t)0x1 << BYTE_IDX_6)
+#define SPI_SLAVE_8_SELECT			((UINT8_t)0x1 << BYTE_IDX_7)
+
+#define IS_SPI_SSN_VALID(SS)		((SS == SPI_SLAVE_1_SELECT) || (SS == SPI_SLAVE_2_SELECT) || (SS == SPI_SLAVE_3_SELECT) || \
+									 (SS == SPI_SLAVE_4_SELECT) || (SS == SPI_SLAVE_5_SELECT) || (SS == SPI_SLAVE_6_SELECT) || \
+									 (SS == SPI_SLAVE_7_SELECT)	||	(SS == SPI_SLAVE_8_SELECT))
+
+
+#define IS_SPIx_VALID(n)			((n == SPI0_MASTER_SEL) || (n == SPI1_MASTER_SEL))
+
+/*! \def SPI0_MASTER_SEL
+    \brief A macro to select Sensor SPI Master controller in FFE subsystem
+*/
+#define SPI0_MASTER_SEL				0
+
+/*! \def SPI1_MASTER_SEL
+    \brief A macro to select SPI Master controller connected to SPI Flash
+*/
+#define SPI1_MASTER_SEL				1
+
+/*! \def I2C_0_SELECT
+    \brief A macro to select I2C_0 as slave to be accessed by WB master
+*/
+#define I2C_0_SELECT				((UINT8_t)0x0)
+
+/*! \def I2C_1_SELECT
+    \brief A macro to select I2C_1 as slave to be accessed by WB master
+*/
+#define I2C_1_SELECT				((UINT8_t)0x40)
+
+/*! \def SPI_0_SELECT
+    \brief A macro to select SPI_0 as slave to be accessed by WB master
+*/
+#define SPI_0_SELECT				((UINT8_t)0x80)
+
+/*! \def SPI0_MUX_SEL_WB_MASTER
+    \brief A macro to define SPI_0 wishbone control mux select
+*/
+#define SPI0_MUX_SEL_WB_MASTER		((UINT8_t)0x80)
+
+/*!
+ * \brief The following macros define the Sensor SPI Master register offsets
+ */
+#define SPI0_BR_LSB_REG				0x0
+#define SPI0_BR_MSB_REG				0x1
+#define SPI0_CFG_REG				0x2
+#define SPI0_TX_RX_REG				0x3
+#define SPI0_CMD_STS_REG			0x4
+#define SPI0_SS_REG				0x5
+#define SPI0_CLK_CTRL_REG			0x6
+#define SPI0_ADD_CLK_REG			0x7
+
+#define SPI_BAUDRATE_625KHZ			((UINT32_t)625000)
+#define SPI_BAUDRATE_1MHZ			((UINT32_t)1000000)
+#define SPI_BAUDRATE_2_5MHZ			((UINT32_t)2500000)
+#define SPI_BAUDRATE_5MHZ			((UINT32_t)5000000)
+#define SPI_BAUDRATE_6MHZ			((UINT32_t)6000000)
+#define SPI_BAUDRATE_8MHZ			((UINT32_t)8000000)
+#define SPI_BAUDRATE_10MHZ			((UINT32_t)10000000)
+#define SPI_BAUDRATE_15MHZ          ((UINT32_t)15000000)
+#define SPI_BAUDRATE_20MHZ          ((UINT32_t)20000000)
+   
+
+/*!
+ * \brief SPI command register (offset 0x4) bit definition
+ */
+#define SPI_CMD_START				((UINT8_t)(1 << BYTE_IDX_0))
+#define SPI_CMD_STOP				((UINT8_t)(1 << BYTE_IDX_1))
+#define SPI_CMD_WRITE				((UINT8_t)(1 << BYTE_IDX_2))
+#define SPI_CMD_READ				((UINT8_t)(1 << BYTE_IDX_3))
+#define SPI_CMD_IACK				((UINT8_t)(1 << BYTE_IDX_7))
+
+/*!
+ * \brief SPI Interrupt/Status register bit definition
+ */
+#define SPI_STAT_TIP				((UINT8_t) (1 << BYTE_IDX_2))
+#define SPI_INTR_IW				((UINT8_t) (1 << BYTE_IDX_1))
+#define SPI_INTR_IR				((UINT8_t) (1 << BYTE_IDX_0))
+
+
+/*!
+ * \brief SPI configuration register (offset 0x2) bit definition
+ */
+#define SPI_SYSTEM_EN				((UINT8_t)(1 << BYTE_IDX_7))
+#define SPI_INTR_EN				((UINT8_t)(1 << BYTE_IDX_6))
+
+#define SPI_MS_INTR_EN				((UINT32_t)0x40000)
+
+#define SPI1_XFER_LEN_MAX			260
+
+#define CTX_ISR 1
+#define CTX_TASK    2
+
+
+/********************** Exported Functions ********************/
+/*!
+* \fn      void HAL_SPI_IRQHandler(void);
+* \brief   SPI TX Interrupt handler
+* \param   None
+* \return  None
+*/
+void HAL_SPI_IRQHandler(void);
+
+/*!
+* \fn      void HAL_SPI_Init(SPI_HandleTypeDef  *hspi))
+* \brief   Initializes the SPI Master controller
+* \param   hspi --- SPI handle
+* \return  None
+*/
+HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef  *hspi);
+
+/*!
+* \fn      void HAL_SPI_DeInit()
+* \brief   De-initializes the SPI HAL
+* \param   None
+* \return  None
+*/
+HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef  *hspi);
+
+/*!
+*\fn       HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef  *hspi, UINT8_t *pData, UINT16_t ulTxLen, void (*HAL_SPI_Callback)(void))
+*\brief    Transmit an amount of data, if callback funtion is NULL, it will be blocking call otherwise Non-Blocking. 
+*           In non blocking mode, callback function will be called from interrupt contex after data is Transmitted from FIFO
+*\param    hspi --- SPI handle
+*\param    pData --- Pointer to data buffer
+*\param    ulTxLen --- amount of data to be sent
+*\param    HAL_SPI_Callback --- Callback function, will be called after Transmit is done
+*\return   HAL status
+*/
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef  *hspi, UINT8_t *pData, UINT32_t ulTxLen, void (*HAL_SPI_Callback)(void));
+
+
+/*!
+* \fn      HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, const UINT16_t usTxSize, UINT8_t *pRxData,const UINT16_t usRxSize,
+*                                          void (*HAL_SPI_TxRxComplCallback)(void))
+* \brief   Transmit an amount of data and reads data in DMA mode, if callback function is Null, it will be a blocking call
+*   otherwise Non-Blocking , In Non Blocking mode Read complete will be notified in callback function
+* \param   hspi        --- SPI Handle
+* \param   pTxData     --- pointer to transmission data buffer
+* \param   pRxData     --- pointer to reception data buffer
+* \param   usTxSize    --- amount of data to be sent
+* \param   usRxSize    --- amount of data to be received
+* \param   HAL_SPI_TxRxComplCallback --- callback function to be called after received data
+* \return  HAL status
+*/
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, const UINT32_t usTxSize,UINT8_t *pRxData, const UINT32_t usRxSize,void (*HAL_SPI_TxRxComplCallback)(void));
+
+/*!
+* \fn      HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, UINT8_t *pRxData,const UINT16_t usRxSize,
+*                                          void (*HAL_SPI_RxCompCallback)(void))
+* \brief   Reads data in DMA mode, if callback function is Null, it will be a blocking call
+*          otherwise Non-Blocking, In Non Blocking mode Read complete will be notified in callback function
+* \param   hspi        --- SPI Handle
+* \param   pTxData     --- pointer to transmission data buffer
+* \param   pRxData     --- pointer to reception data buffer
+* \param   usTxSize    --- amount of data to be sent
+* \param   usRxSize    --- amount of data to be received
+* \param   HAL_SPI_RxCompCallback --- callback function to be called after received data
+* \return  HAL status
+*/
+HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, UINT8_t *pRxData,const UINT16_t usRxSize,
+								void (*HAL_SPI_RxCompCallback)(void));
+
+/*!
+* \fn      void SPI_DMA_Complete(SPI_HandleTypeDef  *hspi)
+* \brief   Callback for SPI Flash Read DMA complete
+* \param   SPI Handle
+* \return  None
+*/
+void SPI_DMA_Complete(void);
+
+/*!
+* \fn      void lock_spi1_bus()
+* \brief   Take Lock of SPI bus for exclusive access to a Task
+* \param   None
+* \return  None
+*/
+void lock_spi1_bus(void);
+
+/*!
+* \fn      static void SPI_Enable(SPI_HandleTypeDef *hspi, UINT8_t ucEnable)
+* \brief   Function to enable/disable SPI master
+* \param   ucEnable --- Enable/Disable flag
+* \param   hspi     --- SPI Handle
+* \return  None
+*/
+//static void SPI_Enable(SPI_HandleTypeDef *hspi, UINT8_t ucEnable);
+
+/*!
+* \fn      void unlock_spi1_bus(UINT8_t Ctx)
+* \brief   Release  Lock of SPI bus for take earlier for exclusive access
+* \param   Ctx  --- Context from where LOck is released, use value CTX_ISR when released from ISR, CTX_TASK when released from Task Context
+* \return  None
+*/
+void unlock_spi1_bus(UINT8_t Ctx);
+
+
+/*!
+ * \fn 		HAL_StatusTypeDef HAL_SPI_TransmitReceive2(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, const UINT16_t usTxSize, UINT8_t *pRxData,const UINT16_t usRxSize,
+ *											void (*HAL_SPI_TxRxComplCallback)(SPI_HandleTypeDef *hspi))
+ *
+ *
+ * \brief	Transmits an amount of data in non-DMA mode and reads the data back in polling mode
+ * \param	hspi		--- SPI Handle
+ * \param	pTxData		--- pointer to transmission data buffer
+ * \param	pRxData		--- pointer to reception data buffer
+ * \param	usTxSize 	--- amount of data to be sent
+ * \param	usRxSize	--- amount of data to be received
+ * \param	callback function
+ * \return	HAL status
+ */
+HAL_StatusTypeDef HAL_SPI_TransmitReceive2(SPI_HandleTypeDef *hspi, UINT8_t *pTxData, const UINT32_t usTxSize, UINT8_t *pRxData,const UINT32_t usRxSize,
+                                           void (*HAL_SPI_TxRxComplCallback)(void));
+
+
+
+#endif /* TAMAR_HAL_SPI_H_ */

--- a/HAL/inc/eoss3_hal_timer.h
+++ b/HAL/inc/eoss3_hal_timer.h
@@ -1,0 +1,67 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_timer.h
+ *    Purpose   : This file contains macros and APIs for
+ *             M4 peripheral timer 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_INC_EOSS3_HAL_TIMER_H_
+#define HAL_INC_EOSS3_HAL_TIMER_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+
+typedef struct __Timer_HandleTypeDef
+{
+     UINT32_t	ulClkFreq;
+     UINT32_t   ulReload_val;
+     
+}Timer_HandleTypeDef;
+   
+/* Ctrl register bit definition */
+#define TIMER_INT_ENABLE	(UINT32_t)(1 << BYTE_IDX_3)
+#define SEL_EXTINT_AS_CLK	(UINT32_t)(1 << BYTE_IDX_2)
+#define SEL_EXTINT_AS_EN	(UINT32_t)(1 << BYTE_IDX_1)
+#define TIMER_ENABLE		(UINT32_t)(1 << BYTE_IDX_0)
+
+#define HAL_TIMER_ONESHOT	(1 << 1)
+#define HAL_TIMER_PERIODIC	(1 << 0)
+
+typedef void (*HAL_TimerCallback_t)(void *);
+struct HAL_Timer_t;
+typedef struct HAL_Timer_t* HAL_Timer_t;
+
+HAL_StatusTypeDef HAL_Delay_Init(void);
+void HAL_DelayUSec(uint32_t usecs);
+
+HAL_StatusTypeDef HAL_TimerCreate(HAL_Timer_t *Timer, uint32_t USecs,
+				  uint32_t Flags, HAL_TimerCallback_t CallBack,
+				  void *Cookie);
+HAL_StatusTypeDef HAL_TimerStart(HAL_Timer_t Timer);
+HAL_StatusTypeDef HAL_TimerStop(HAL_Timer_t Timer);
+HAL_StatusTypeDef HAL_TimerDelete(HAL_Timer_t Timer);
+
+HAL_StatusTypeDef HAL_Timer_Enable( );                          // to remove warnings 
+HAL_StatusTypeDef HAL_Timer_Disable( );							// function declarations
+
+
+#endif /* HAL_INC_EOSS3_HAL_TIMER_H_ */

--- a/HAL/inc/eoss3_hal_uart.h
+++ b/HAL/inc/eoss3_hal_uart.h
@@ -1,0 +1,251 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_uart.h
+ *    Purpose   : This file contains macros, structures and APIs for
+ *             UART read/write 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __TAMAR_HAL_UART_H_
+#define __TAMAR_HAL_UART_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*!	\enum UartBaudRateType
+	\brief Uart baudrate
+*/
+typedef enum
+{
+	BAUD_2400 = 0,
+	BAUD_4800,
+	BAUD_9600,
+	BAUD_19200,
+	BAUD_38400,
+	BAUD_57600,
+	BAUD_115200,
+	BAUD_230400,
+	BAUD_460800,
+	BAUD_921600,
+	BAUD_INVALID,
+} UartBaudRateType;
+
+/*!	\enum UartWordLenType
+	\brief Uart wordlength to transfer/receive
+*/
+typedef enum
+{
+	WORDLEN_8B = 0,
+	WORDLEN_7B,
+	WORDLEN_6B,
+	WORDLEN_5B,
+	WORDLEN_INVALID = -1,
+} UartWordLenType;
+
+/*!	\enum UartStopBitsType
+	\brief Uart stopbits selection
+*/
+typedef enum
+{
+	STOPBITS_1 = 0,
+	STOPBITS_2,
+	STOPBIT_INVALID = -1,
+} UartStopBitsType;
+
+/*!	\enum UartParityType
+	\brief Uart parity type
+*/
+typedef enum
+{
+	PARITY_NONE = 0,
+	PARITY_EVEN,
+	PARITY_ODD,
+} UartParityType;
+
+/*!	\enum UartModeType
+	\brief Uart operation mode
+*/
+typedef enum
+{
+	DISABLE_MODE = 0,
+	TX_MODE,
+	RX_MODE,
+	TX_RX_MODE
+} UartModeType;
+
+/*!	\enum UartHwFlowCtrl
+	\brief Uart H/W flow control selection
+*/
+typedef enum
+{
+	HW_FLOW_CTRL_DISABLE = 0,
+	HW_FLOW_CTRL_ENABLE,
+} UartHwFlowCtrl;
+
+/*!	\enum UartInterruptMode
+	\brief Uart interrupt mode selection
+*/
+typedef enum
+{
+	UART_INTR_DISABLE = 0,
+	UART_INTR_ENABLE
+} UartInterruptMode;
+
+/*!	\enum CpuClk
+	\brief CPU clock for UART configuration
+*/
+typedef enum
+{
+	CLK_2_33 = 0,
+	CLK_77_76,
+	CLK_19,
+	CLK_40,
+	CLK_2_2,
+	CLK_10,
+} CpuClk;
+
+#if !defined(UART_ID_CONSOLE)
+/* most often, the UART_HW */
+#define UART_ID_CONSOLE UART_ID_HW
+#endif
+#if !defined(UART_ID_DBG)
+/* most often, the UART_HW but could be disabled */
+#define UART_ID_DBG UART_ID_HW
+#endif
+
+#define UART_ID_DISABLED  0 /* /dev/null */
+#define UART_ID_HW        1 /* the hard UART on the S3 */
+#define UART_ID_SEMIHOST  2
+#define UART_ID_FPGA      3 /* second uart if part of FPGA */
+
+#define UART_ID_BOOTLOADER  UART_ID_HW
+
+
+/*! \struct UartHandler eoss3_hal_uart.h "inc/eoss3_hal_uart.h"
+ * 	\brief UART configuration structure filled in by user.
+ */
+typedef struct
+{
+    CpuClk                 cpuClk;		/*!< CPU clock rate */
+    UartBaudRateType       baud;		/*!< Uart baud rate */
+    UartWordLenType        wl;			/*!< Uart word length */
+    UartStopBitsType       stop;		/*!< Uart stop bit */
+    UartParityType         parity;		/*!< Uart parity bit */
+    UartModeType           mode;		/*!< Uart operation mode */
+    UartHwFlowCtrl         hwCtrl;		/*!< Uart H/W Flow control */
+    UartInterruptMode      intrMode;		/*!< Uart interrupt mode */
+    uint32_t               lcr_h_value;
+    uint32_t               cr_value;
+    uint32_t               ibrd_value;
+    uint32_t               fbrd_value;
+    int                    lpm_enabled;
+}UartHandler;
+
+
+void uart_pm_update( int uartid, int is_wakeup );
+
+void uart_init(int uartid, const UartHandler *pConfig );
+
+/* newbaudrate can be:  BAUD_9600, or 9600 */
+void uart_new_baudrate( int uartid, uint32_t newbaudrate );
+
+void uart_isr_handler(int uartid);
+
+/**
+ * @brief Send byte over UART.
+ *
+ *  @param uartid   which uart
+ *  @param c		Byte to transmit over UART
+ *
+ *  Raw does not perform lf -> cr/lf mapping.
+ *  Where as "non-raw" does perform lf->cr/lf mapping
+ */
+void uart_tx_raw(int uartid, int c);
+
+/**
+ * @brief Send byte over UART.
+ *
+ *  @param uartid   which uart
+ *  @param c		Byte to transmit over UART
+ *
+ *  Raw does not perform lf -> cr/lf mapping.
+ *  Where as "non-raw" does perform lf->cr/lf mapping
+ */
+void uart_tx(int uartid, int c);
+
+/**
+ * @brief Send buffer over UART.
+ *
+ *  @param uartid   which uart
+ *  @param data     bytes to send
+ *  @param len      count of bytes.
+ *
+ *  Raw does not perform lf -> cr/lf mapping.
+ *  Where as "non-raw" does perform lf->cr/lf mapping
+ */
+
+void uart_tx_raw_buf(int uartid, const uint8_t *data,size_t len);
+
+/**
+ * @brief Send buffer over UART.
+ *
+ *  @param uartid   which uart
+ *  @param data     bytes to send
+ *  @param len      count of bytes.
+ *
+ *  Raw does not perform lf -> cr/lf mapping.
+ *  Where as "non-raw" does perform lf->cr/lf mapping
+ */
+void uart_tx_buf(int uartid, const uint8_t *data,size_t len);
+
+/* wait till a byte is ready, or timeout */
+int uart_rx_wait( int uartid, int timeout );
+/**
+ * @brief Return number of bytes available in input buffer.
+ *
+ * @param uartid   which uart.
+ *
+ */
+int uart_rx_available(int uartid );
+
+/**
+ * @brief Read N bytes from uart into buffer
+ *
+ * @param uartid   which uart.
+ *
+ * This is a RAW uart api, and does not preform cr/lf mapping -> lf.
+ */
+int uart_rx_raw_buf( int uartid, uint8_t *puthere, size_t nbytes );
+
+/**
+ * @brief Read byte from uart, blocking does not return
+ */
+int uart_rx(int uartid);
+
+/**
+ * @brief Set uart lpm enable or disable
+ * 
+ * @param 1 = enable, 0 = disable
+ */
+void uart_set_lpm_state(int uart_id, int lpm_en);
+
+/*
+ * @}
+ */
+#endif /* !__TAMAR_HAL_UART_H_ */

--- a/HAL/inc/eoss3_hal_wb.h
+++ b/HAL/inc/eoss3_hal_wb.h
@@ -1,0 +1,86 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_wb.h
+ *    Purpose :  
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef HAL_INC_EOSS3_HAL_WB_H_
+#define HAL_INC_EOSS3_HAL_WB_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "test_types.h"
+#include "eoss3_hal_def.h"
+
+/*!
+ * \brief WB_ADDR register definition
+ */
+#define WB_ADDR_SPI0_SLAVE_SEL		((UINT8_t)(0x2 << BYTE_IDX_6))
+#define WB_ADDR_I2C1_SLAVE_SEL		((UINT8_t)(0x1 << BYTE_IDX_6))
+#define WB_ADDR_I2C0_SLAVE_SEL		((UINT8_t)(0x0 << BYTE_IDX_6))
+
+/*!
+ *\brief Wishbone Control and status register definition
+ */
+#define WB_CSR_SPI0MUX_SEL_WBMASTER		((UINT8_t)(1 << BYTE_IDX_7))
+#define WB_CSR_SPI0MUX_SEL_SM1                  ((UINT8_t)(0 << BYTE_IDX_7))        
+#define WB_CSR_I2C1MUX_SEL_WBMASTER             ((UINT8_t)(1 << BYTE_IDX_6))
+#define WB_CSR_I2C1MUX_SEL_SM1			((UINT8_t)(0 << BYTE_IDX_6))
+#define WB_CSR_I2C0MUX_SEL_WBMASTER             ((UINT8_t)(1 << BYTE_IDX_5))
+#define WB_CSR_I2C0MUX_SEL_SM0			((UINT8_t)(0 << BYTE_IDX_5))
+
+#define WB_CSR_MASTER_WR_EN			((UINT8_t)(1 << BYTE_IDX_1))
+#define WB_CSR_MASTER_START			((UINT8_t)(1 << BYTE_IDX_0))
+#define WB_CSR_BUSY				((UINT8_t)(1 << BYTE_IDX_3))
+#define WB_CSR_OVFL				((UINT8_t)(1 << BYTE_IDX_4))
+
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSlaveSel)
+ * \brief 	Function to send data over Wishbone interface
+ * \param	ucOffset        --- Wishbone register offset
+ * \param       ucVal           --- Data
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSlaveSel);
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Receive(UINT8_t ucOffset, UINT8_t *buf, UINT8_t ucSlaveSel)
+ * \brief 	Function to read data over Wishbone interface
+ * \param	ucOffset        --- Wishbone register offset
+ * \param       ucVal           --- Data
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Receive(UINT8_t ucOffset, UINT8_t *buf, UINT8_t ucSlaveSel);
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
+ * \brief 	Function to initialize Wishbone interface
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel);
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_DeInit(UINT8_t ucSlaveSel)
+ * \brief 	Function to De-initialize Wishbone interface
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_DeInit(UINT8_t ucSlaveSel);
+
+#endif /* HAL_INC_EOSS3_HAL_WB_H_ */

--- a/HAL/inc/eoss3_hal_wdt.h
+++ b/HAL/inc/eoss3_hal_wdt.h
@@ -1,0 +1,34 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_wdt.h
+ *    Purpose   : 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __EOSS3_HAL_WDT_H__
+#define __EOSS3_HAL_WDT_H__
+#include "eoss3_hal_def.h"
+
+HAL_StatusTypeDef HAL_WDT_Init(unsigned int secs_timeout);
+HAL_StatusTypeDef HAL_WDT_DeInit(void);
+HAL_StatusTypeDef HAL_WDT_Start(void);
+HAL_StatusTypeDef HAL_WDT_Stop(void);
+HAL_StatusTypeDef HAL_WDT_Reload(void);
+HAL_StatusTypeDef HAL_WDT_WdtIsStartStatus(void);
+
+#endif

--- a/HAL/inc/s3x_clock_hal.h
+++ b/HAL/inc/s3x_clock_hal.h
@@ -1,0 +1,138 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : s3x_clock_hal.h
+ *    Purpose   : 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#ifndef __S3X_CLOCK_HAL_H
+#define __S3X_CLOCK_HAL_H
+
+
+#include "eoss3_dev.h"
+#include "test_types.h"
+#define MHZ 1000000
+#define KHZ 1000
+
+
+typedef enum
+{
+    /*C01 clk gate*/
+   S3X_A0_01_CLK,           //  0 to A0 ********** A0 from C08 also. Need to check ******************
+   S3X_SDMA_SRAM_CLK,       //  1 to SDMA SRAM
+   S3X_PKT_FIFO_CLK,        //  2 to Packet FIFO
+   S3X_FFE_CLK,             //  3 to FFE
+   S3X_CFG_DMA_A1_CLK,      //  4 to CFG DMA Bridge inside A1 / AHB2APB bridge
+   S3X_I2S_A1_CLK,          //  5 to I2S module inside A1
+   S3X_SDMA_CLK,            //  6 to SDMA
+   S3X_EFUSE_01_CLK,        // 7 to eFuse        *********** eFUSE from C02 also. Need to check***************
+   S3X_SPT_CLK,             // 8 to SPT
+
+
+   /*C02 clk gate*/
+   S3X_A1_CLK,              // 9 to A1 including CFGSM
+   S3X_FB_02_CLK,           // 10 to FB           *********** FB from C16 also. Need to check******************
+   S3X_EFUSE_02_CLK,        // 11 to eFuse        *********** eFUSE from C01 also. Need to check***************
+
+
+   /*C08 X4 clk gate*/
+   S3X_FFE_X4_CLK,          // 12 to FFE X4 clk
+
+   /*C08 X1 clk gate*/
+   S3X_FFE_X1_CLK,          // 13 to FFE X1 clk
+   S3X_A0_08_CLK,           // 14 to A0 ********** A0 from C01 also. Need to check ******************
+   S3X_ASYNC_FIFO_0_CLK,    // 15 to PF ASYNC FIFO 0
+
+  /*C9 Clk Gate */
+   S3X_AUDIO_APB,           // 16
+   S3X_CLKGATE_PIF,         // 17
+   S3X_CLKGATE_FB,          //18
+   /*C10 clk gate*/
+    /*TODO : Check for S3X_M4_BM_TB_CLK. Current status - Not handled*/
+   S3X_M4_BM_TB_CLK, //  19 to M4 Bus Matrix and Trace block
+                     //  This bit will be set if any of the Memories (M4S0~M4S3)been wakeup  by Hardware.
+   S3X_M4_S0_S3_CLK,// 20 to M4 SRAM Instance, M4S0~M4S3.
+   S3X_M4_S4_S7_CLK,// 21 to M4 SRAM Instance, M4S4~M4S7
+   S3X_M4_S8_S11_CLK,// 22 to M4 SRAM Instance, M4S8~M4S11
+   S3X_M4_S12_S15_CLK,// 23 to M4 SRAM Instance, M4S12~M4S15
+   S3X_AUDIO_DMA_CLK,// 24 to AUDIO DMA
+   S3X_SYNCUP_A0_AHB_CLK,// 25 to the SYNC Up on A0 and AHB Interface of Batching Memory
+
+   /*C11 clk gate*/
+   S3X_M4_PRPHRL_CLK,// 26 to M4 peripherals - AHB/APB bridge, UART, WDT and TIMER
+
+   /*CS clk gate*/
+   S3X_SWD_PIN_CLK, //  27 to SWD Clk from PIN
+
+   /*C16 clk gate*/
+   S3X_FB_16_CLK, // 28 to FB *********** FB from C02 also. Need to check******************
+
+   /*CLK reserved 0*/
+
+   /*C19 clk gate*/
+   S3X_ADC_CLK,// 29 To ADC
+
+   /*C21 clk gate*/
+   S3X_FB_21_CLK, // 30 To FB(additional clock) ********** FB from C16 also. Need to check******************
+
+   /* C30 C31 */
+   S3X_PDM_LEFT,    //31
+   S3X_PDM_RIGHT,   //32
+   S3X_PDM_STEREO,  //33
+   S3X_I2S_MASTER,  //34
+   S3X_LPSD,        //35
+   S3X_MAX_CLK      //36
+}S3x_CLK_ID;
+#define MAX_QOS_REQ 3
+typedef enum {
+    MIN_HSOSC_FREQ = 0x1,
+    MIN_CPU_FREQ = 0x2,
+    MIN_OP_FREQ = 0x4,
+    OP_REQ_END = 0x4
+} QOS_REQ_TYPE;
+
+/*To enable clock. Pass the clock ID as defined in the enum S3x_CLK_ID*/
+int S3x_Clk_Enable(UINT32_t clk_id);
+
+/*To disable clock. Pass the clock ID as defined in the enum S3x_CLK_ID*/
+int S3x_Clk_Disable(UINT32_t clk_id);
+
+/*To set clock rate. Pass the cloack ID and the desired rate*/
+int S3x_Clk_Set_Rate(UINT32_t clk_id, UINT32_t rate);
+
+/**To set clock rate. Pass the clock ID and the desired range of rate (min  and max rate value)*/
+//int S3x_Clk_Set_Rate(UINT32_t clk_id, UINT32_t rate_min,  UINT32_t rate_max);
+
+/*To get the rate for the corresponding clock ID. Pass the clock ID as defined in the enum S3x_CLK_ID*/
+int S3x_Clk_Get_Rate(UINT32_t clk_id);
+
+/*To get Status for the clock*/
+int S3x_Clk_Get_Status(UINT32_t clk_id);
+
+/*To get the use count for the clock ID (gate)*/
+int S3x_Clk_Get_Usecnt(UINT32_t clk_id);
+
+int S3x_Register_Qos_Node(UINT32_t clk_id);
+
+int S3x_Set_Qos_Req(UINT32_t clk_id, QOS_REQ_TYPE, UINT32_t val);
+
+int S3x_Get_Qos_Req(UINT32_t clk_id, QOS_REQ_TYPE req);
+
+int S3x_Clear_Qos_Req(UINT32_t clk_id, QOS_REQ_TYPE);
+
+#endif      /* __S3X_CLOCK_HAL_H  */

--- a/HAL/inc/test_types.h
+++ b/HAL/inc/test_types.h
@@ -1,0 +1,74 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : test_types.h
+ *    Purpose   : 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+ 
+#ifndef __TEST_TYPES_H_
+#define __TEST_TYPES_H_
+
+#include <stdio.h>
+#include <stdint.h>
+
+/* FIXME:  The CAPNAME versions need to go away */
+
+/*! \typedef char INT8_t
+ *	\brief signed character type
+ */
+typedef int8_t	INT8_t;
+
+/*! \typedef unsigned char UINT8_t
+ *	\brief unsigned character type
+ */
+typedef uint8_t	UINT8_t;
+
+/*! \typedef short INT16_t
+ *	\brief signed short type
+ */
+typedef int16_t	INT16_t;
+
+/*! \typedef unsigned short UINT16_t
+ *	\brief unsigned short type
+ */
+typedef uint16_t	UINT16_t;
+
+/*! \typedef int INT32_t
+ *	\brief signed integer type
+ */
+typedef int32_t	INT32_t;
+
+/*! \typedef unsigned int UINT32_t
+ *	\brief unsigned integer type
+ */
+typedef uint32_t	UINT32_t;
+
+/*! \typedef float FLOAT_t
+ *	\brief float type
+ */
+typedef float	FLOAT_t;
+
+/*! \typedef unsigned char	BYTE
+ *	\brief unsigned char type
+ *	\ This type MUST be 8-bit
+ */
+typedef unsigned char	BYTE;
+
+
+
+#endif /* __TEST_TYPES_H_ */

--- a/HAL/src/CMakeLists.txt
+++ b/HAL/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+# QuickLogic HAL
+#
+# Copyright (c) 2020 Antmicro Ltd <www.antmicro.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_GPIO_EOS_S3)
+	zephyr_sources(eoss3_hal_gpio.c)
+	zephyr_sources(eoss3_hal_pad_config.c)
+endif()

--- a/HAL/src/eoss3_hal_gpio.c
+++ b/HAL/src/eoss3_hal_gpio.c
@@ -1,0 +1,150 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_gpio.c
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             read/write GPIO
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+
+#include <stdint.h>
+#include <errno.h>
+#include "eoss3_hal_gpio.h"
+#include "eoss3_hal_def.h"
+#include "eoss3_dev.h"
+
+/*!
+ * \brief array containing reg offset (wrt S_INTR_SEL_BASE) and correponding register value to be selected for each PAD
+    Bit 7:4 - register offset from S_INTR_SEL_BASE (0x40004D3C)
+    Bit 3:0 - register value to be written for selecting the particular PAD
+*/
+const uint8_t gpio_intr_cfg[PAD_COUNT] = {0x0,0x0,0x11,0x01,0x21,0x31,
+					   0x12,0x41,0x22,0x32,0x42,0x51,
+					   0x61,0x71,0x52,0x62,0x0,0x0,
+					   0x13,0x0,0x0,0x23,0x32,0x72,
+					   0x14,0x24,0x43,0x53,0x34,0x44,
+					   0x54,0x63,0x64,0x73,0x74,0x15,
+					   0x16,0x25,0x26,0x35,0x36,0x65,
+					   0x75,0x0,0x45,0x55
+  
+};
+
+void HAL_GPIO_Read(uint8_t ucGpioIndex, uint8_t *ucGpioVal)
+{
+	if(ucGpioIndex <= GPIO_7)
+	{
+		*ucGpioVal = ((MISC_CTRL->IO_INPUT >> ucGpioIndex) & 1);
+	}
+}
+
+void HAL_GPIO_Write(uint8_t ucGpioIndex, uint8_t ucGpioVal)
+{
+	if((ucGpioIndex <= GPIO_7) && (ucGpioVal <= 1) )
+	{
+		if(ucGpioVal)
+		{
+			MISC_CTRL->IO_OUTPUT |=  (1 << ucGpioIndex);
+		}
+		else
+		{
+			MISC_CTRL->IO_OUTPUT &= ~(1 << ucGpioIndex);
+		}
+	}
+}
+
+int HAL_GPIO_IntrCfg(GPIOCfgTypeDef *hGpioCfg)
+{
+	int gpio_irq_num;
+
+	switch (hGpioCfg->xPadConf->ucPin) {
+	case PAD_6:
+		IO_MUX->S_INTR_1_SEL_REG = 2;
+		gpio_irq_num = 1;
+		break;
+	case PAD_9:
+		IO_MUX->S_INTR_3_SEL_REG = 2;
+		gpio_irq_num = 3;
+		break;
+	case PAD_11:
+		IO_MUX->S_INTR_5_SEL_REG = 1;
+		gpio_irq_num = 5;
+		break;
+	case PAD_14:
+		IO_MUX->S_INTR_5_SEL_REG = 2;
+		gpio_irq_num = 5;
+		break;
+	case PAD_18:
+		IO_MUX->S_INTR_1_SEL_REG = 3;
+		gpio_irq_num = 1;
+		break;
+	case PAD_21:
+		IO_MUX->S_INTR_2_SEL_REG = 3;
+		gpio_irq_num = 2;
+		break;
+	case PAD_22:
+		IO_MUX->S_INTR_3_SEL_REG = 3;
+		gpio_irq_num = 3;
+		break;
+	case PAD_23:
+		IO_MUX->S_INTR_7_SEL_REG = 2;
+		gpio_irq_num = 7;
+		break;
+	case PAD_24:
+		IO_MUX->S_INTR_1_SEL_REG = 4;
+		gpio_irq_num = 1;
+		break;
+	case PAD_26:
+		IO_MUX->S_INTR_4_SEL_REG = 3;
+		gpio_irq_num = 4;
+		break;
+	case PAD_28:
+		IO_MUX->S_INTR_3_SEL_REG = 4;
+		gpio_irq_num = 3;
+		break;
+	case PAD_30:
+		IO_MUX->S_INTR_5_SEL_REG = 4;
+		gpio_irq_num = 5;
+		break;
+	case PAD_31:
+		IO_MUX->S_INTR_6_SEL_REG = 3;
+		gpio_irq_num = 6;
+		break;
+	case PAD_36:
+		IO_MUX->S_INTR_1_SEL_REG = 6;
+		gpio_irq_num = 1;
+		break;
+	case PAD_38:
+		IO_MUX->S_INTR_2_SEL_REG = 6;
+		gpio_irq_num = 2;
+		break;
+	case PAD_45:
+		IO_MUX->S_INTR_5_SEL_REG = 5;
+		gpio_irq_num = 5;
+		break;
+	default:
+		return -EINVAL;
+
+	};
+
+	INTR_CTRL->GPIO_INTR_TYPE &= (~((UINT32_t) (0x1) << gpio_irq_num)); //zero the bit position
+	INTR_CTRL->GPIO_INTR_TYPE |= (hGpioCfg->intr_type << gpio_irq_num); //update the bit with desired value
+
+	INTR_CTRL->GPIO_INTR_POL &= (~((UINT32_t) (0x1) << gpio_irq_num)); //zero the bit position
+	INTR_CTRL->GPIO_INTR_POL |= (hGpioCfg->pol_type << gpio_irq_num); //update the bit with desired value
+
+	return gpio_irq_num;
+}

--- a/HAL/src/eoss3_hal_pad_config.c
+++ b/HAL/src/eoss3_hal_pad_config.c
@@ -1,0 +1,224 @@
+/*
+ * ==========================================================
+ *
+ *    Copyright (C) 2020 QuickLogic Corporation             
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    File      : eoss3_hal_pad_config.c
+ *    Purpose   : This file contains macros, structures and APIs to
+ *             configure pads 
+ *                                                          
+ *                                                          
+ * ===========================================================
+ *
+ */
+#include <eoss3_hal_pad_config.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/// @cond <section name>
+#define  OUTPUT_EN		((uint8_t)0x00)   /* Output Enable */
+#define  INPUT_DIS		((uint8_t)0x00)   /* Input Disable */
+#define  OUTPUT_DRV_DIS		((uint8_t)0x01)   /* Output Disable */
+
+#define EXT_REGS_MAX	44
+#define EXT_REGS_PADS_VARS_MAX	8
+#define IO_INPUT_MAX	8
+#define IO_MUX_MAX  2
+
+#define DEFAULT_VAL_0   0
+#define DEFAULT_VAL_1   1
+#define DEFAULT_VAL_N1   -1
+
+/*Extended Pad config register offset starts from */
+/*! \var int8_t  SEL_EXT_PAD_REGS
+    \brief This array contains all the possible pad selection for given register.
+    These registers are extention to PAD config registers [0 to 45]. First value 
+    in an array is default value and rest indexes need to be written for given pad.
+    Offset of extended register starts from 0x100. This offset is embedded in each 
+    pad function macro.
+*/
+
+const int8_t  SEL_EXT_PAD_REGS[EXT_REGS_MAX][EXT_REGS_PADS_VARS_MAX] = {
+      {DEFAULT_VAL_1, PAD_1}, //100
+      {DEFAULT_VAL_1, PAD_15,PAD_32,PAD_44}, //104
+      {DEFAULT_VAL_1, PAD_41}, //108
+      {DEFAULT_VAL_1, PAD_0}, //10C
+      {DEFAULT_VAL_1, PAD_14, PAD_33, PAD_45}, //110
+      {DEFAULT_VAL_1, PAD_40}, //114
+      {PAD_16, PAD_0}, //118 
+      {PAD_20, PAD_0}, //11C 
+      {PAD_19, PAD_0}, //120
+      {PAD_36, PAD_0}, //124 
+      {DEFAULT_VAL_0, PAD_10, PAD_28}, //128
+      {DEFAULT_VAL_0, PAD_10, PAD_28}, //12C
+      {DEFAULT_VAL_N1}, //Dummy 130
+      {DEFAULT_VAL_0, PAD_14,PAD_16,PAD_25,PAD_45}, //GAP 134
+      {DEFAULT_VAL_0, PAD_6,PAD_15,PAD_21,PAD_24,PAD_28,PAD_40,PAD_44}, //138
+      {DEFAULT_VAL_0, PAD_3}, //13C
+      {DEFAULT_VAL_0, PAD_2,PAD_6,PAD_18,PAD_24,PAD_35,PAD_36}, //140
+      {DEFAULT_VAL_0, PAD_4,PAD_8,PAD_21,PAD_25,PAD_37,PAD_38}, //144
+      {DEFAULT_VAL_0, PAD_5,PAD_9,PAD_22,PAD_28,PAD_39,PAD_40}, //148
+      {DEFAULT_VAL_0, PAD_7,PAD_10,PAD_26,PAD_29,PAD_44}, //14C
+      {DEFAULT_VAL_0, PAD_11,PAD_14,PAD_27,PAD_30,PAD_45}, //150
+      {DEFAULT_VAL_0, PAD_12,PAD_15,PAD_31,PAD_32,PAD_41}, //154
+      {DEFAULT_VAL_0, PAD_13,PAD_23,PAD_33,PAD_34,PAD_42}, //158
+      {DEFAULT_VAL_1, PAD_17,PAD_22}, //15C
+      {DEFAULT_VAL_0, 0}, //160 //IO_REG_SEL, handled seperately using an arry IO_INPUT_PAD_SEL
+      {DEFAULT_VAL_N1, 0}, //Dummy 164
+      {DEFAULT_VAL_N1, 0}, //Dummy 168
+      {DEFAULT_VAL_N1, 0}, //Dummy 16C
+      {DEFAULT_VAL_1, 0}, //170 Debugger pad selection happed using bootstap pin
+      {DEFAULT_VAL_1, 0}, //174 Debugger pad selection happed using bootstap pin
+      {DEFAULT_VAL_N1, 0}, //Dummy 178
+      {DEFAULT_VAL_N1, 0}, //Dummy 17C
+      {DEFAULT_VAL_1, 0}, //180 FBIO : Special handling for each bit
+      {DEFAULT_VAL_1, PAD_32}, //184 FBIO : Special handling for each bit (we can subtract 
+      {DEFAULT_VAL_0, 0}, //Dummy 188
+      {DEFAULT_VAL_0, 0}, //Dummy 18C								
+      {DEFAULT_VAL_0, PAD_8,PAD_29}, //190
+      {DEFAULT_VAL_0, PAD_6,PAD_28}, //194
+      {DEFAULT_VAL_N1, 0}, //Dummy 198
+      {DEFAULT_VAL_N1, 0}, //Dummy 19C
+      {DEFAULT_VAL_0, PAD_23}, //1A0
+      {DEFAULT_VAL_0, PAD_31}, //1A4
+      {DEFAULT_VAL_0, PAD_9,PAD_30}, //0x1A8
+      {DEFAULT_VAL_0, PAD_38}, //0x1AC			
+      };
+
+/*! \var uint8_t IO_INPUT_PAD_SEL
+    \brief This array contains pad selection for GPIO input configuration written in 
+    IO_REG_SEL register.
+*/
+const uint8_t IO_INPUT_PAD_SEL[IO_INPUT_MAX][IO_MUX_MAX] =
+      {{PAD_6,PAD_24}, {PAD_9,PAD_26}, {PAD_11,PAD_28}, {PAD_14,PAD_30},
+      {PAD_18,PAD_31},{PAD_21,PAD_36},{PAD_22,PAD_38},{PAD_23,PAD_45}};
+
+/// @endcond
+
+void HAL_PAD_Config(PadConfig *pxPadInit)
+{
+	PadConfigReg xPadRegVal;
+	uint32_t *pExtRegAddr;
+	uint32_t uiExtRegAddr;
+	uint8_t ucCount, ucIdx;
+	int8_t ucIsValid=false;
+
+	memset(&xPadRegVal, 0, sizeof(uint32_t));
+
+	xPadRegVal.bCtrl = pxPadInit->ucCtrl;
+
+	xPadRegVal.bFunc = pxPadInit->ucFunc & 0x03; /*Since we have been using only two bits to define function.*/
+
+	xPadRegVal.bOPull = pxPadInit->ucPull;
+	xPadRegVal.bODrv = pxPadInit->ucDrv;
+	xPadRegVal.bSpeed = pxPadInit->ucSpeed;
+	xPadRegVal.bSmtTrg = pxPadInit->ucSmtTrg;
+	
+	ucIsValid = false;
+    /* In case of output mode selection */
+    if((pxPadInit->ucMode == PAD_MODE_OUTPUT_EN))
+    {
+    	ucIsValid = true;
+    	xPadRegVal.bOEn = OUTPUT_EN;
+	xPadRegVal.bIEn = INPUT_DIS;
+    }
+    else if((pxPadInit->ucMode == PAD_MODE_INPUT_EN))
+    {
+    	ucIsValid = true;
+    	xPadRegVal.bOEn = OUTPUT_DRV_DIS;
+	xPadRegVal.bIEn = pxPadInit->ucMode;
+    }
+
+    if(ucIsValid)
+    {
+    	pExtRegAddr = (uint32_t *)IO_MUX;
+    	pExtRegAddr += pxPadInit->ucPin;
+
+	memcpy(pExtRegAddr, &xPadRegVal, sizeof(uint32_t));
+    }
+
+    /*Check if it needs any additional register need to be configured or Pad selection to be performed*/
+    if( (uiExtRegAddr = (pxPadInit->ucFunc >> EXT_REG_OFFSET_SHIFT)) )
+    {
+    	/*Check if special handling needed.*/
+    	if((uiExtRegAddr == FBIO_SEL_1) ||  (uiExtRegAddr == FBIO_SEL_2))
+    	{
+    		if(uiExtRegAddr == FBIO_SEL_2)
+    		{
+    			uiExtRegAddr = uiExtRegAddr | IO_MUX_BASE;
+    			pExtRegAddr = (uint32_t *)uiExtRegAddr;
+    			*pExtRegAddr |= 1 << (pxPadInit->ucPin - 32);
+    		}
+    		else
+    		{
+    			uiExtRegAddr |= IO_MUX_BASE;
+    			pExtRegAddr = (uint32_t *)uiExtRegAddr;
+    			*pExtRegAddr |= 1 << pxPadInit->ucPin;
+    		}
+    	}
+    	else if(uiExtRegAddr == IO_REG_SEL) /*GPIO Input Configuration*/
+    	{
+    		ucIsValid = false;
+    		/*GPIO Input configuration*/
+    		if((pxPadInit->ucMode == PAD_MODE_INPUT_EN))
+    		{
+    			for(ucIdx=0; ucIdx<IO_INPUT_MAX; ucIdx++)
+    			{
+    				for(ucCount=0;ucCount<IO_MUX_MAX;ucCount++)
+    				{
+    					if(IO_INPUT_PAD_SEL[ucIdx][ucCount] == pxPadInit->ucPin)
+    					{
+    						/*Found requested pad in Input array*/
+    						ucIsValid = true;
+    						uiExtRegAddr |= IO_MUX_BASE;
+    						pExtRegAddr = (uint32_t *)uiExtRegAddr;
+    						*pExtRegAddr |= ucCount << ucIdx;
+    						break;
+    					}
+    				}
+    			}
+    		}
+    	}
+    	else
+    	{
+    		ucIsValid = false;
+
+			/*Check if it is not pointing to dummy address*/
+			if(SEL_EXT_PAD_REGS[(uiExtRegAddr - EXT_REG_OFFSET_BASE)/4][0] ==  -1)
+			{
+				ucIsValid = false;
+			}
+			else
+			{
+                /*Start searching pad from index 1 as 0th is default value*/
+				for(ucCount = 1; ucCount < EXT_REGS_PADS_VARS_MAX; ucCount++)
+				{
+					/*Compare pin number in the extended register array finding index in that two dimensional array*/
+					if(SEL_EXT_PAD_REGS[(uiExtRegAddr - EXT_REG_OFFSET_BASE)/4][ucCount] ==  pxPadInit->ucPin)
+					{
+						uiExtRegAddr |= IO_MUX_BASE;
+						pExtRegAddr = (uint32_t *)uiExtRegAddr;
+						*pExtRegAddr = ucCount;
+						break;
+					}
+				}
+			}
+    	}
+    }
+}
+
+void HAL_PAD_DeConfig(PadConfig *pxPadInit)
+{
+	//Write Padconfig register to default values
+	//Write Ext pad config register to def value.
+}

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: .


### PR DESCRIPTION
This is the initial release of the EOS S3 HAL from QuickLogic.

It will be used for Chandalar and QuickFeather boards in Zephyr.