### PR TITLE
ci: license_check: Update to scancode action v4

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Scan the code
       id: scancode
-      uses: zephyrproject-rtos/action_scancode@v2
+      uses: zephyrproject-rtos/action_scancode@v4
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload


### PR DESCRIPTION
This commit updates the license check workflow to use the v4 release
of the scancode action, which uses a more recent scancode version.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>