### PR TITLE
EOS S3 Hal i2c and wishbone bus

### DIFF
--- a/HAL/src/CMakeLists.txt
+++ b/HAL/src/CMakeLists.txt
@@ -7,4 +7,6 @@
 if(CONFIG_GPIO_EOS_S3)
 	zephyr_sources(eoss3_hal_gpio.c)
 	zephyr_sources(eoss3_hal_pad_config.c)
+	zephyr_sources(eoss3_hal_i2c.c)
+	zephyr_sources(eoss3_hal_wb.c)
 endif()

--- a/HAL/src/eoss3_hal_i2c.c
+++ b/HAL/src/eoss3_hal_i2c.c
@@ -1,0 +1,1036 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+/*!	\file eoss3_hal_i2c.c
+ *
+ *  \brief This file contains API implementation for the I2C
+ *         Controller(s) in the EOS S3
+ */
+#include "Fw_global_config.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+#include <eoss3_dev.h>
+#include <eoss3_hal_def.h>
+#include <s3x_clock_hal.h>
+//#include <eoss3_hal_rcc.h>
+#include <eoss3_hal_i2c.h>
+#include <eoss3_hal_pad_config.h>
+#include "test_types.h"
+#include <eoss3_hal_wb.h>
+//#include "eoss3_hal_power.h"
+#include "Fw_global_config.h"
+
+#ifdef __RTOS
+#include <FreeRTOS.h>
+#include <semphr.h>
+#endif
+#define delayCycles(_x_)	do {							\
+					volatile unsigned int _delayCycleCount = _x_;	\
+					while (_delayCycleCount--);			\
+				} while(0)
+
+/* This variable holds I2C status */
+I2C_State eI2CState = I2C_RESET;
+UINT8_t   ucI2CSlaveID = WB_ADDR_I2C0_SLAVE_SEL;
+
+HAL_StatusTypeDef HAL_I2C0_Select()
+{
+  ucI2CSlaveID = WB_ADDR_I2C0_SLAVE_SEL;
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C1_Select()
+{
+  ucI2CSlaveID = WB_ADDR_I2C1_SLAVE_SEL;
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_Init(I2C_Config xI2CConfig)
+{
+    if(xI2CConfig.ucI2Cn == 0)
+    {
+    	HAL_WB_Init(WB_ADDR_I2C0_SLAVE_SEL);
+	HAL_I2C0_Select();
+    }
+    if(xI2CConfig.ucI2Cn == 1)
+    {
+	HAL_WB_Init(WB_ADDR_I2C1_SLAVE_SEL);
+	HAL_I2C1_Select();
+    }
+
+    HAL_WB_Transmit(I2C_MCR, (UINT8_t)~(1<<I2C_CR_EN_BIT), ucI2CSlaveID);
+
+    /* Set I2C clock frequency */
+    HAL_I2C_SetClockFreq(xI2CConfig.eI2CFreq);
+
+    /* Check if Interrupt needs to be enable */
+    if(xI2CConfig.eI2CInt)
+          HAL_WB_Transmit(I2C_MCR, 1<<I2C_CR_IEN_BIT, ucI2CSlaveID);
+
+    HAL_WB_Transmit(I2C_MCR, 1<<I2C_CR_EN_BIT, ucI2CSlaveID);
+
+	eI2CState = I2C_READY;
+	return HAL_OK;
+}
+/*
+* Note:  12-14-2018
+* The Datasheet seems to be not updated to the correct RTL implementation.
+* The macro HAL_I2C_CLK_PRESCALE is incorrect due to this.
+*      I2C_FREQ ? (SYS_FREQ/(I2C_FREQ*5))-1
+*
+* The computation should be according to the following formula.
+* For pre-scale  = 0:
+*
+*  Default I2C frequency  (with control register bit [4] = bit[5] = 0)  =  Sys Freq. / 12
+* 
+* For pre-scale  > 0:
+*
+*  I2C SCL Freq  = Sys Freq / (5 * (pre-scale +1) + X ,       
+*        1. Where X  is added because of the clock stretching support, filtering of the feedback path 
+*           to know whether clock is being stretched or not. 
+*        2. X varies according to the pre-scale value.
+*           For pre-scale (1-3 ), X = 5
+*           For pre-scale (4-7 ), X = 7
+*           For pre-scale (8-11 ), X = 9 
+*           For pre-scale (12-15 ), X =11 and So On
+*
+* So, the values are precomputed for a lookup in a Table
+*/
+#define CHECK_DIV_ARRAY_SIZE  16
+//static int divArray[CHECK_DIV_ARRAY_SIZE]      = {12,15,20,25,32,37,42,47,54,59,64,69,76,81,86,91};
+static int checkDivArray[CHECK_DIV_ARRAY_SIZE] = {13,17,22,29,34,39,44,50,56,61,66,72,78,83,88,91};
+//int checkDivArraySize = 16;
+static int CalculatePreScale(float divFactor)
+{
+    int i;
+    for (i = 0; i < CHECK_DIV_ARRAY_SIZE; i++)
+    {
+        if (divFactor <= checkDivArray[i])
+        {
+            return i;
+        }
+    }
+    return CHECK_DIV_ARRAY_SIZE-1;
+}
+
+HAL_StatusTypeDef HAL_I2C_SetClockFreq(UINT32_t uiClkFreq)
+{
+    UINT32_t uiClock, uiPrescale;
+    UINT8_t val;
+   //Set the frequency
+    uiClock = S3x_Clk_Get_Rate(S3X_FFE_X1_CLK);
+
+    // Program prescale value
+#if 1 //use new formula to compute    
+    uiPrescale = CalculatePreScale(uiClock*1.0/(uiClkFreq*100*1000));
+#else  //this is incorrect according to RTL   
+    uiPrescale = HAL_I2C_CLK_PRESCALE(uiClock, (uiClkFreq*100*1000));
+#endif    
+//    HAL_I2C_WRITE_PRESCALE(uiPrescale);
+    HAL_WB_Transmit(I2C_PRELO, uiPrescale&0xFF, ucI2CSlaveID);
+    HAL_WB_Transmit(I2C_PREHI, (uiPrescale>>8)&0xFF, ucI2CSlaveID);
+
+    HAL_WB_Receive(I2C_PRELO, &val, ucI2CSlaveID);
+
+    return HAL_OK;
+}
+
+
+HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ucAddress, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Check if Transfer completed */
+    do
+    {
+      HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+      	eI2CState = I2C_READY;
+      	return HAL_ERROR;
+    }
+
+    /* Write data */
+    if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+
+    /* Generate command with write cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Write data */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ucAddress, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Request for Read */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) | 1), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Generate command with ACK and READ cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+    /* Check if Transfer completed */
+
+    do
+    {
+       HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+  /* Read data */
+    HAL_WB_Receive(I2C_TXRX_DR, pucData++, ucI2CSlaveID);
+  }
+
+  /* Generate command with ACK and READ cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_NACK_BIT | CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read data */
+  HAL_WB_Receive(I2C_TXRX_DR, pucData, ucI2CSlaveID);
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+
+HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, (ucAddress>>8)&0xff, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+    /* Generate command with write cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ucAddress&0xff, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+  
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Request for Read */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) | 1), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Generate command with ACK and READ cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+    /* Check if Transfer completed */
+
+    do
+    {
+       HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+  /* Read data */
+    HAL_WB_Receive(I2C_TXRX_DR, pucData++, ucI2CSlaveID);
+  }
+
+  /* Generate command with ACK and READ cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_NACK_BIT | CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read data */
+  HAL_WB_Receive(I2C_TXRX_DR, pucData, ucI2CSlaveID);
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+  //HAL_SetPowerDomainState(FFE,WAKEUP);
+  delayCycles(50);
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+  
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, (ucAddress>>8)&0xff, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+    /* Generate command with write cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ucAddress&0xff, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Check if Transfer completed */
+    do
+    {
+      HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+      	eI2CState = I2C_READY;
+      	return HAL_ERROR;
+    }
+
+    /* Write data */
+    if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+
+    /* Generate command with write cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Write data */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_Read_UsingRestart(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Write address */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ucAddress, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, /* CMD_STOP_BIT | */ CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+  	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Request for Read */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) | 1), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Generate command with ACK and READ cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+    /* Check if Transfer completed */
+
+    do
+    {
+       HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+  /* Read data */
+    HAL_WB_Receive(I2C_TXRX_DR, pucData++, ucI2CSlaveID);
+  }
+
+  /* Generate command with ACK and READ cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_NACK_BIT | CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read data */
+  HAL_WB_Receive(I2C_TXRX_DR, pucData, ucI2CSlaveID);
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_ReadRawData(UINT8_t ucDevAddress, UINT8_t *pucDataBuf, UINT32_t uiLength)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = uiLength-1;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  if(!uiLength)
+    return HAL_OK;
+
+  eI2CState = I2C_BUSY;
+  /* Request for Read */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) | 1), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read acknowledge from slave */
+  if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+  {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  while(uiLen--)
+  {
+    /* Generate command with ACK and READ cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+    /* Check if Transfer completed */
+
+    do
+    {
+       HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+        eI2CState = I2C_READY;
+    	return HAL_ERROR;
+    }
+
+  /* Read data */
+    HAL_WB_Receive(I2C_TXRX_DR, pucData++, ucI2CSlaveID);
+  }
+
+  /* Generate command with ACK and READ cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_NACK_BIT | CMD_READ_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+    	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  /* Read data */
+  HAL_WB_Receive(I2C_TXRX_DR, pucData, ucI2CSlaveID);
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}
+
+HAL_StatusTypeDef HAL_I2C_WriteRawData(UINT8_t ucDevAddress, UINT8_t *pucDataBuf, UINT32_t uiLength, int stop)
+{
+  UINT8_t *pucData = pucDataBuf;
+  UINT32_t uiLen = (uiLength > 0) ? uiLength-1 : 0;
+  UINT8_t ucI2CStatus = 0;
+
+  if(eI2CState != I2C_READY)
+    return HAL_BUSY;
+
+  if(!ucDevAddress || pucDataBuf == NULL)
+    return HAL_ERROR;
+
+  eI2CState = I2C_BUSY;
+
+  /* Request for write */
+  if(HAL_WB_Transmit(I2C_TXRX_DR, ((ucDevAddress<<1) & (~1)), ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Generate command with start condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+    	eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+  for (uint32_t ibyte = 0; ibyte < uiLen; ibyte++)
+  {
+    /* Check if Transfer completed */
+    do
+    {
+      HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+    }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+    /* Read acknowledge from slave */
+    if((ucI2CStatus & (1<<SR_RXACK_BIT)))
+    {
+      	eI2CState = I2C_READY;
+      	return HAL_ERROR;
+    }
+
+    /* Write data */
+    if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+	return HAL_ERROR;
+    }
+
+    /* Generate command with write cycle */
+    if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+    {
+      	eI2CState = I2C_READY;
+ 	return HAL_ERROR;
+    }
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+     HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  if (uiLength > 0)
+  {
+	  /* Write data */
+	  if(HAL_WB_Transmit(I2C_TXRX_DR, *pucData++, ucI2CSlaveID) != HAL_OK)
+	  {
+			eI2CState = I2C_READY;
+		return HAL_ERROR;
+	  }
+  }
+  if (stop) {
+	  stop = CMD_STOP_BIT;
+  } else
+  {
+	  stop = 0;
+  }
+  /* Generate command with stop condition and write cycle */
+  if(HAL_WB_Transmit(I2C_CMD_SR, stop | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
+  {
+		eI2CState = I2C_READY;
+	return HAL_ERROR;
+  }
+
+  /* Check if Transfer completed */
+  do
+  {
+	 HAL_WB_Receive(I2C_CMD_SR, &ucI2CStatus, ucI2CSlaveID);
+  }while(ucI2CStatus & (1<<SR_TIP_BIT));
+
+  eI2CState = I2C_READY;
+
+  return HAL_OK;
+}

--- a/HAL/src/eoss3_hal_i2c.c
+++ b/HAL/src/eoss3_hal_i2c.c
@@ -19,22 +19,16 @@
  *  \brief This file contains API implementation for the I2C
  *         Controller(s) in the EOS S3
  */
-#include "Fw_global_config.h"
-
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 #include <stddef.h>
 #include <eoss3_dev.h>
 #include <eoss3_hal_def.h>
-#include <s3x_clock_hal.h>
-//#include <eoss3_hal_rcc.h>
 #include <eoss3_hal_i2c.h>
 #include <eoss3_hal_pad_config.h>
 #include "test_types.h"
 #include <eoss3_hal_wb.h>
-//#include "eoss3_hal_power.h"
-#include "Fw_global_config.h"
 
 #ifdef __RTOS
 #include <FreeRTOS.h>
@@ -133,8 +127,14 @@ HAL_StatusTypeDef HAL_I2C_SetClockFreq(UINT32_t uiClkFreq)
 {
     UINT32_t uiClock, uiPrescale;
     UINT8_t val;
-   //Set the frequency
-    uiClock = S3x_Clk_Get_Rate(S3X_FFE_X1_CLK);
+    //Set the frequency
+    //uiClock = S3x_Clk_Get_Rate(S3X_FFE_X1_CLK); // TODO: FIX - add CLOCK rate getting function
+    /* Get Source Clock (CL08_X4) Rate, which is equal to High Speed OSC (HSOSC) clock Rate 
+     * and divide it accordingly. NOTE: This below assumes HSOSC rate is not modified (and by
+     * default it is not) 
+     * #define OSC_GET_FREQ_INC()	(((AIP->OSC_CTRL_1 & 0xFFF) + 3) * 32768)
+    */
+    uiClock = (((AIP->OSC_CTRL_1 & 0xFFF) + 3) * 32768)/4/6; // TODO: Find a programatic way to get the dividor (6) from CLK_CTRL_C_0, supposedly done here: https://github.com/QuickLogic-Corp/qorc-sdk/blob/d61d064146c0ee927aa12b088b3bbbce60615f4d/Libraries/Power/src/s3x_clock.c#L685
 
     // Program prescale value
 #if 1 //use new formula to compute    

--- a/HAL/src/eoss3_hal_i2c.c
+++ b/HAL/src/eoss3_hal_i2c.c
@@ -1,5 +1,8 @@
 /*==========================================================
  * Copyright 2020 QuickLogic Corporation
+ *    Copyright (C) 2023 Szymon Duchniewicz
+ *    Copyright (C) 2023 Jakub Duchniewicz
+ *    Copyright (C) 2023 Avanade Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +26,12 @@
 #include <stdint.h>
 #include <string.h>
 #include <stddef.h>
-#include <eoss3_dev.h>
-#include <eoss3_hal_def.h>
-#include <eoss3_hal_i2c.h>
-#include <eoss3_hal_pad_config.h>
+#include "eoss3_dev.h"
+#include "eoss3_hal_def.h"
+#include "eoss3_hal_i2c.h"
+#include "eoss3_hal_pad_config.h"
 #include "test_types.h"
-#include <eoss3_hal_wb.h>
+#include "eoss3_hal_wb.h"
 
 #ifdef __RTOS
 #include <FreeRTOS.h>
@@ -133,7 +136,6 @@ HAL_StatusTypeDef HAL_I2C_SetClockFreq(UINT32_t uiClkFreq)
     UINT32_t uiClock, uiPrescale;
     UINT8_t val;
     //Set the frequency
-    //uiClock = S3x_Clk_Get_Rate(S3X_FFE_X1_CLK); // TODO: FIX - add CLOCK rate getting function
     /* Get Source Clock (CL08_X4) Rate, which is equal to High Speed OSC (HSOSC) clock Rate 
      * and divide it accordingly. NOTE: This below assumes HSOSC rate is not modified (and by
      * default it is not) 

--- a/HAL/src/eoss3_hal_i2c.c
+++ b/HAL/src/eoss3_hal_i2c.c
@@ -38,6 +38,11 @@
 					volatile unsigned int _delayCycleCount = _x_;	\
 					while (_delayCycleCount--);			\
 				} while(0)
+#define MAX_CYCLES_FFE 50 // how many cycles to wait after each write to TXRX data register for i2c, for FFE to stop being busy - pick up the data and transmit to the i2c device (otherwise will fail on next transmission function)
+#define waitFFEReady(_x_) for (int i = 0; i != _x_; i++) \
+                                  if (!((EXT_REGS_FFE->CSR & WB_CSR_BUSY) \
+                                              || (EXT_REGS_FFE->CSR & WB_CSR_MASTER_START)))\
+                                              break;
 
 /* This variable holds I2C status */
 I2C_State eI2CState = I2C_RESET;
@@ -175,6 +180,7 @@ HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -201,6 +207,7 @@ HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -230,6 +237,7 @@ HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t
       	eI2CState = I2C_READY;
 	return HAL_ERROR;
     }
+    waitFFEReady(MAX_CYCLES_FFE);
 
     /* Generate command with write cycle */
     if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -251,6 +259,7 @@ HAL_StatusTypeDef HAL_I2C_Write(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -293,6 +302,7 @@ HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t 
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -320,6 +330,7 @@ HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t 
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -340,6 +351,7 @@ HAL_StatusTypeDef HAL_I2C_Read(UINT8_t ucDevAddress, UINT8_t ucAddress, UINT8_t 
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -433,6 +445,7 @@ HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -460,6 +473,7 @@ HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
     /* Generate command with write cycle */
     if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -479,6 +493,7 @@ HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
   
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -499,6 +514,7 @@ HAL_StatusTypeDef HAL_I2C_Read16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT8
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -593,6 +609,7 @@ HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with start condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_START_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -620,6 +637,7 @@ HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
     /* Generate command with write cycle */
     if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -640,6 +658,7 @@ HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -669,6 +688,7 @@ HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT
       	eI2CState = I2C_READY;
 	return HAL_ERROR;
     }
+    waitFFEReady(MAX_CYCLES_FFE);
 
     /* Generate command with write cycle */
     if(HAL_WB_Transmit(I2C_CMD_SR, CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)
@@ -690,6 +710,7 @@ HAL_StatusTypeDef HAL_I2C_Write16(UINT8_t ucDevAddress, UINT16_t ucAddress, UINT
     	eI2CState = I2C_READY;
 	return HAL_ERROR;
   }
+  waitFFEReady(MAX_CYCLES_FFE);
 
   /* Generate command with stop condition and write cycle */
   if(HAL_WB_Transmit(I2C_CMD_SR, CMD_STOP_BIT | CMD_WRITE_SLAVE_BIT, ucI2CSlaveID) != HAL_OK)

--- a/HAL/src/eoss3_hal_wb.c
+++ b/HAL/src/eoss3_hal_wb.c
@@ -1,5 +1,7 @@
 /*==========================================================
  * Copyright 2020 QuickLogic Corporation
+ *    Copyright (C) 2023 Szymon Duchniewicz
+ *    Copyright (C) 2023 Avanade Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +59,6 @@ HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSla
                   else if(ucSlaveSel == WB_ADDR_I2C0_SLAVE_SEL)
                     EXT_REGS_FFE->CSR = (WB_CSR_I2C0MUX_SEL_WBMASTER | WB_CSR_MASTER_WR_EN | WB_CSR_MASTER_START);
 
-		  //QL_LOG_DBG_150K("addr = %x, csr = %x\r\n",EXT_REGS_FFE->ADDR,EXT_REGS_FFE->CSR);
         	return HAL_OK;
         }
 

--- a/HAL/src/eoss3_hal_wb.c
+++ b/HAL/src/eoss3_hal_wb.c
@@ -1,0 +1,259 @@
+/*==========================================================
+ * Copyright 2020 QuickLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *==========================================================*/
+
+/*==========================================================
+ *                                                          
+ *    File   : eoss3_hal_wb.c
+ *    Purpose: This file contains HAL API for Wishbone Master inside
+ *             FFE subsystem
+ *                                                          
+ *=========================================================*/
+#include "Fw_global_config.h"
+
+/* Standard includes. */
+#include <stdio.h>
+#include <string.h>
+
+#include "eoss3_dev.h"
+//#include "eoss3_hal_ffe.h"
+//#include "eoss3_hal_rcc.h"
+#include "eoss3_hal_pad_config.h"
+#include "eoss3_hal_wb.h"
+#include <test_types.h>
+#include "s3x_clock_hal.h"
+#include "dbg_uart.h"
+
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSlaveSel)
+ * \brief 	Function to send data over Wishbone interface
+ * \param	ucOffset        --- Wishbone register offset
+ * \param       ucVal           --- Data
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSlaveSel)
+{
+        UINT32_t ulRegVal = 0;
+
+        ulRegVal = EXT_REGS_FFE->CSR;
+
+        if (!((ulRegVal & WB_CSR_BUSY) || (ulRegVal & WB_CSR_MASTER_START))) {
+                  //bits[7:6] = 2 to select SPI as slave by WB master
+                  EXT_REGS_FFE->ADDR = (ucSlaveSel | ucOffset);
+                  EXT_REGS_FFE->WDATA = ucVal;
+
+                  if(ucSlaveSel == WB_ADDR_SPI0_SLAVE_SEL)
+                    EXT_REGS_FFE->CSR = (WB_CSR_SPI0MUX_SEL_WBMASTER | WB_CSR_MASTER_WR_EN | WB_CSR_MASTER_START);
+                  else if(ucSlaveSel == WB_ADDR_I2C1_SLAVE_SEL)
+                    EXT_REGS_FFE->CSR = (WB_CSR_I2C1MUX_SEL_WBMASTER | WB_CSR_MASTER_WR_EN | WB_CSR_MASTER_START);
+                  else if(ucSlaveSel == WB_ADDR_I2C0_SLAVE_SEL)
+                    EXT_REGS_FFE->CSR = (WB_CSR_I2C0MUX_SEL_WBMASTER | WB_CSR_MASTER_WR_EN | WB_CSR_MASTER_START);
+
+		  //QL_LOG_DBG_150K("addr = %x, csr = %x\r\n",EXT_REGS_FFE->ADDR,EXT_REGS_FFE->CSR);
+        	return HAL_OK;
+        }
+
+	return HAL_ERROR;
+}
+
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Receive(UINT8_t ucOffset, UINT8_t *buf, UINT8_t ucSlaveSel)
+ * \brief 	Function to read data over Wishbone interface
+ * \param	ucOffset        --- Wishbone register offset
+ * \param       ucVal           --- Data
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Receive(UINT8_t ucOffset, UINT8_t *buf, UINT8_t ucSlaveSel)
+{
+        UINT32_t ulReg_val = 0;
+	UINT8_t ucCnt = 10;
+
+	EXT_REGS_FFE->ADDR = (ucSlaveSel | ucOffset);
+
+        if(ucSlaveSel == WB_ADDR_SPI0_SLAVE_SEL)
+          EXT_REGS_FFE->CSR = (WB_CSR_SPI0MUX_SEL_WBMASTER | WB_CSR_MASTER_START);
+        else if(ucSlaveSel == WB_ADDR_I2C1_SLAVE_SEL)
+          EXT_REGS_FFE->CSR = (WB_CSR_I2C1MUX_SEL_WBMASTER | WB_CSR_MASTER_START);
+        else if(ucSlaveSel == WB_ADDR_I2C0_SLAVE_SEL)
+          EXT_REGS_FFE->CSR = (WB_CSR_I2C0MUX_SEL_WBMASTER | WB_CSR_MASTER_START);
+
+
+	//Check for status
+        do {
+                ulReg_val = EXT_REGS_FFE->CSR;
+                if (!((ulReg_val & WB_CSR_MASTER_START) || (ulReg_val & WB_CSR_BUSY)))
+                        break;
+                ucCnt--;
+        } while (ucCnt > 0);
+
+        *buf = EXT_REGS_FFE->RDATA;
+
+        return HAL_OK;
+}
+
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
+ * \brief 	Function to initialize Wishbone interface
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
+{
+        PadConfig  padcfg;
+
+        //enable FFE power & clock domain
+        PMU->FFE_PWR_MODE_CFG = 0x0;
+        PMU->FFE_PD_SRC_MASK_N = 0x0;
+        PMU->FFE_WU_SRC_MASK_N = 0x0;
+
+        //wake up FFE
+        PMU->FFE_FB_PF_SW_WU = 0x1;
+        //check if FFE is in Active mode
+        while(!(PMU->FFE_STATUS & 0x1));
+
+	//HAL_SetClkGate(FFE_X1_CLK_TOP, C08X1_CLK_GATE_FFE_X1CLK,1);
+//	HAL_SetClkGate(EFUSE_SDMA_I2S_FFE_PF_CLK_TOP, C01_CLK_GATE_FFE,1);
+        S3x_Clk_Enable(S3X_FFE_X1_CLK);
+        S3x_Clk_Enable(S3X_FFE_CLK);
+/*
+        QL_LOG_DBG_150K("c8_x1 freq = %ld\r\n", S3x_Clk_Get_Rate(S3X_FFE_X1_CLK));
+      	QL_LOG_DBG_150K("C01_clk_gate = %x\r\n",CRU->C01_CLK_GATE);
+*/
+        switch(ucSlaveSel)
+        {
+            case WB_ADDR_SPI0_SLAVE_SEL:
+                //MOSI
+                padcfg.ucPin = PAD_6;
+                padcfg.ucFunc = PAD6_FUNC_SPI_SENSOR_MOSI;
+                padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+                padcfg.ucMode = PAD_MODE_OUTPUT_EN;
+                padcfg.ucPull = PAD_NOPULL;
+                padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+                padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+                padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+                HAL_PAD_Config(&padcfg);
+
+        //dbg_str_hex32("MOSI - pad6 =", IO_MUX->PAD_6_CTRL);
+
+                //MISO
+                padcfg.ucPin = PAD_8;
+                padcfg.ucFunc = PAD8_FUNC_SEL_SPI_SENSOR_MISO;
+                padcfg.ucCtrl = PAD_CTRL_SRC_A0;
+                padcfg.ucMode = PAD_MODE_INPUT_EN;
+                padcfg.ucPull = PAD_PULLDOWN;
+                padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+                padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+                padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+                HAL_PAD_Config(&padcfg);
+        //dbg_str_hex32("MISO - pad8", IO_MUX->PAD_8_CTRL);
+
+                //clk
+                padcfg.ucPin = PAD_10;
+                padcfg.ucFunc = PAD10_FUNC_SEL_SPI_SENSOR_CLK;
+                padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+                padcfg.ucMode = PAD_MODE_OUTPUT_EN;
+                padcfg.ucPull = PAD_NOPULL;
+                padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+                padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+                padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+                HAL_PAD_Config(&padcfg);
+        //dbg_str_hex32("CLK - pad10", IO_MUX->PAD_10_CTRL);
+
+                //Slave Select
+                padcfg.ucPin = PAD_9;
+                padcfg.ucFunc = PAD9_FUNC_SEL_SPI_SENSOR_SSn_1;
+                padcfg.ucCtrl = PAD_CTRL_SRC_A0;
+                padcfg.ucMode = PAD_MODE_OUTPUT_EN;
+                padcfg.ucPull = PAD_NOPULL;
+                padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+                padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+                padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+                HAL_PAD_Config(&padcfg);
+
+        //dbg_str_hex32("CS - pad9", IO_MUX->PAD_9_CTRL);
+            break;
+
+            case WB_ADDR_I2C0_SLAVE_SEL:
+
+                padcfg.ucPin = PAD_0;
+		padcfg.ucFunc = PAD0_FUNC_SEL_SCL_0;
+		padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+		padcfg.ucMode = PAD_MODE_INPUT_EN;
+		padcfg.ucPull = PAD_PULLUP;
+		padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+		padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+		padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+		HAL_PAD_Config(&padcfg);
+
+
+		padcfg.ucPin = PAD_1;
+		padcfg.ucFunc = PAD1_FUNC_SEL_SDA_0;
+		padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+		padcfg.ucMode = PAD_MODE_INPUT_EN;
+		padcfg.ucPull = PAD_PULLUP;
+		padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+		padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+		padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+		HAL_PAD_Config(&padcfg);
+              break;
+
+            case WB_ADDR_I2C1_SLAVE_SEL:
+                padcfg.ucPin = PAD_33;
+		padcfg.ucFunc = PAD33_FUNC_SEL_SCL_1;
+		padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+		padcfg.ucMode = PAD_MODE_INPUT_EN;
+		padcfg.ucPull = PAD_PULLUP;
+		padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+		padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+		padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+		HAL_PAD_Config(&padcfg);
+
+
+		padcfg.ucPin = PAD_32;
+		padcfg.ucFunc = PAD32_FUNC_SEL_SDA_1;
+		padcfg.ucCtrl = PAD_CTRL_SRC_OTHER;
+		padcfg.ucMode = PAD_MODE_INPUT_EN;
+		padcfg.ucPull = PAD_PULLUP;
+		padcfg.ucDrv = PAD_DRV_STRENGHT_4MA;
+		padcfg.ucSpeed = PAD_SLEW_RATE_SLOW;
+		padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
+
+		HAL_PAD_Config(&padcfg);
+
+              break;
+        }
+
+        return HAL_OK;
+}
+
+/*!
+ * \fn		HAL_StatusTypeDef HAL_WB_DeInit(UINT8_t ucSlaveSel)
+ * \brief 	Function to De-initialize Wishbone interface
+ * \param       ucSlaveSel      --- Slave Select (I2C1 or I2C0 or SPI)
+ * \return      HAL status
+ */
+HAL_StatusTypeDef HAL_WB_DeInit(UINT8_t ucSlaveSel)
+{
+        return HAL_OK;
+}

--- a/HAL/src/eoss3_hal_wb.c
+++ b/HAL/src/eoss3_hal_wb.c
@@ -21,20 +21,15 @@
  *             FFE subsystem
  *                                                          
  *=========================================================*/
-#include "Fw_global_config.h"
 
 /* Standard includes. */
 #include <stdio.h>
 #include <string.h>
 
 #include "eoss3_dev.h"
-//#include "eoss3_hal_ffe.h"
-//#include "eoss3_hal_rcc.h"
 #include "eoss3_hal_pad_config.h"
 #include "eoss3_hal_wb.h"
 #include <test_types.h>
-#include "s3x_clock_hal.h"
-#include "dbg_uart.h"
 
 /*!
  * \fn		HAL_StatusTypeDef HAL_WB_Transmit(UINT8_t ucOffset, UINT8_t ucVal, UINT8_t ucSlaveSel)
@@ -114,25 +109,7 @@ HAL_StatusTypeDef HAL_WB_Receive(UINT8_t ucOffset, UINT8_t *buf, UINT8_t ucSlave
 HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
 {
         PadConfig  padcfg;
-
-        //enable FFE power & clock domain
-        PMU->FFE_PWR_MODE_CFG = 0x0;
-        PMU->FFE_PD_SRC_MASK_N = 0x0;
-        PMU->FFE_WU_SRC_MASK_N = 0x0;
-
-        //wake up FFE
-        PMU->FFE_FB_PF_SW_WU = 0x1;
-        //check if FFE is in Active mode
-        while(!(PMU->FFE_STATUS & 0x1));
-
-	//HAL_SetClkGate(FFE_X1_CLK_TOP, C08X1_CLK_GATE_FFE_X1CLK,1);
-//	HAL_SetClkGate(EFUSE_SDMA_I2S_FFE_PF_CLK_TOP, C01_CLK_GATE_FFE,1);
-        S3x_Clk_Enable(S3X_FFE_X1_CLK);
-        S3x_Clk_Enable(S3X_FFE_CLK);
-/*
-        QL_LOG_DBG_150K("c8_x1 freq = %ld\r\n", S3x_Clk_Get_Rate(S3X_FFE_X1_CLK));
-      	QL_LOG_DBG_150K("C01_clk_gate = %x\r\n",CRU->C01_CLK_GATE);
-*/
+        /* Previously, FFE power and clock domain was enabled here, now done on SoC init */
         switch(ucSlaveSel)
         {
             case WB_ADDR_SPI0_SLAVE_SEL:
@@ -148,8 +125,6 @@ HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
 
                 HAL_PAD_Config(&padcfg);
 
-        //dbg_str_hex32("MOSI - pad6 =", IO_MUX->PAD_6_CTRL);
-
                 //MISO
                 padcfg.ucPin = PAD_8;
                 padcfg.ucFunc = PAD8_FUNC_SEL_SPI_SENSOR_MISO;
@@ -161,7 +136,6 @@ HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
                 padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
 
                 HAL_PAD_Config(&padcfg);
-        //dbg_str_hex32("MISO - pad8", IO_MUX->PAD_8_CTRL);
 
                 //clk
                 padcfg.ucPin = PAD_10;
@@ -174,7 +148,6 @@ HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
                 padcfg.ucSmtTrg = PAD_SMT_TRIG_DIS;
 
                 HAL_PAD_Config(&padcfg);
-        //dbg_str_hex32("CLK - pad10", IO_MUX->PAD_10_CTRL);
 
                 //Slave Select
                 padcfg.ucPin = PAD_9;
@@ -188,7 +161,6 @@ HAL_StatusTypeDef HAL_WB_Init(UINT8_t ucSlaveSel)
 
                 HAL_PAD_Config(&padcfg);
 
-        //dbg_str_hex32("CS - pad9", IO_MUX->PAD_9_CTRL);
             break;
 
             case WB_ADDR_I2C0_SLAVE_SEL:


### PR DESCRIPTION
This PR adds HAL definitions for I2C driver which uses the WIshbone bus onboard the EOS S3 SoC, used in the QuickFeather board (https://docs.zephyrproject.org/latest/boards/arm/quick_feather/doc/index.html) and the QuickThing+ board (https://github.com/sparkfun/QuickLogic_Thing_Plus).

it is based on the EOS S3 HAL for FreeRTOS: https://github.com/antmicro/eos-s3-hal

There is a small fix I need to introduce (currently hardcoded Clock dividor value), which needs to be read and calculated from the proper register at runtime.

Opening this PR as I am currently at EOSS and want to get initial feedback, also will be opening a PR to main zephyr repo that will require this module to be updated before it can be merged in (I2C Zephyr driver for EOS S3 SoC)