### PR TITLE
HAL: eoss3_dev: add missing `__cplusplus` handling

### DIFF
--- a/HAL/inc/eoss3_dev.h
+++ b/HAL/inc/eoss3_dev.h
@@ -2463,5 +2463,9 @@ typedef struct
 #define REBOOT_CAUSE		(0xF)
 #define REBOOT_STATUS_REG	(PMU->MISC_POR_3)
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
 #endif /* __EOSS3_DEV_H */
 


### PR DESCRIPTION
Close out the `extern "C"` definition at the top of the file when C++ is enabled.